### PR TITLE
Rolling PR for version 1.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'commander-openflighthpc', '~> 2.1'
 gem 'hashie'
 gem 'xdg'
 gem 'output_mode'
+gem 'tty-markdown', '~> 0.6.0'
+gem 'word_wrap'
 
 group :development do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     equatable (0.6.1)
     hashie (4.1.0)
     highline (2.0.3)
+    kramdown (1.16.2)
     method_source (1.0.0)
     necromancer (0.6.0)
     output_mode (1.0.0)
@@ -26,6 +27,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
+    rouge (3.22.0)
     slop (4.8.2)
     strings (0.1.8)
       strings-ansi (~> 0.1)
@@ -33,6 +35,13 @@ GEM
       unicode_utils (~> 1.4)
     strings-ansi (0.2.0)
     tty-color (0.5.2)
+    tty-markdown (0.6.0)
+      kramdown (~> 1.16.2)
+      pastel (~> 0.7.2)
+      rouge (~> 3.3)
+      strings (~> 0.1.4)
+      tty-color (~> 0.4)
+      tty-screen (~> 0.6)
     tty-screen (0.8.1)
     tty-table (0.11.0)
       equatable (~> 0.6)
@@ -42,6 +51,7 @@ GEM
       tty-screen (~> 0.7)
     unicode-display_width (1.7.0)
     unicode_utils (1.4.0)
+    word_wrap (1.0.0)
     xdg (4.2.0)
 
 PLATFORMS
@@ -53,6 +63,8 @@ DEPENDENCIES
   output_mode
   pry
   pry-byebug
+  tty-markdown (~> 0.6.0)
+  word_wrap
   xdg
 
 BUNDLED WITH

--- a/etc/config.reference
+++ b/etc/config.reference
@@ -49,6 +49,14 @@ config :templates_dir, default: File.expand_path('../var/templates', __dir__)
 #<% end -%>
 
 # ==============================================================================
+# Minimum Terminal Width
+# The minimum terminal width when wrapping output text. This prevents various
+# edge cases in small terminals. The terminal is responsible for wrapping the
+# text if its width is smaller than the minimum.
+# ==============================================================================
+config :minimum_terminal_width, default: 80
+
+# ==============================================================================
 # Log Path
 # The file the logger will write to. It will write to standard error when set to
 # empty string.

--- a/lib/flight_job/commands/info.rb
+++ b/lib/flight_job/commands/info.rb
@@ -27,12 +27,13 @@
 
 require 'ostruct'
 require 'erb'
+require_relative '../markdown_renderer'
 
 module FlightJob
   module Commands
     class Info < Command
       TEMPLATE = <<~ERB
-        # <%= filename -%> -- <%= name -%>
+        # <%= filename -%> -- <%= name %>
 
         ## DESCRIPTION
 
@@ -52,7 +53,8 @@ module FlightJob
 
       def run
         bind = OpenStruct.new(template.metadata).instance_exec { self.binding }
-        puts ERB_TEMPLATE.result(bind)
+        rendered = ERB_TEMPLATE.result(bind)
+        puts MarkdownRenderer.new(rendered).wrap_markdown
       end
 
       def template

--- a/lib/flight_job/commands/info.rb
+++ b/lib/flight_job/commands/info.rb
@@ -37,8 +37,8 @@ module FlightJob
 
         ## DESCRIPTION
 
-        <%= desc -%>
-        <%= extended_desc %>
+        <%= desc %>
+        <%= extended_desc -%><%= "\n" if extended_desc -%>
 
         ## LICENSE
 

--- a/lib/flight_job/commands/info.rb
+++ b/lib/flight_job/commands/info.rb
@@ -38,8 +38,7 @@ module FlightJob
         ## DESCRIPTION
 
         <%= desc -%>
-
-        <%= extended_desc -%>
+        <%= extended_desc %>
 
         ## LICENSE
 

--- a/lib/flight_job/markdown_renderer.rb
+++ b/lib/flight_job/markdown_renderer.rb
@@ -1,0 +1,85 @@
+#==============================================================================
+# Copyright (C) 2020-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+require_relative '../patches/tty-markdown'
+require 'word_wrap'
+
+module FlightJob
+  MarkdownRenderer = Struct.new(:content, :width) do
+    attr_reader :colors
+
+    def initialize(*_)
+      super
+      self.width ||= TTY::Screen.width
+      self.width = Config::CACHE.minimum_terminal_width if self.width < Config::CACHE.minimum_terminal_width
+      @colors = 256 # Attempt to use 256-color initially
+    end
+
+    def wrap_markdown
+      parse_markdown.split("\n").map do |padded_line|
+        # Finds the un-padded line and the padding width
+        line = padded_line.sub(/^\s*/, '')
+        pad_width = padded_line.length - line.length
+        padding = ' ' * pad_width
+
+        # Wraps the un-padded line, adjusting for the paddding
+        wrapped_line = WordWrap.ww(line, width - pad_width).chomp
+
+        # Pads the start and additional new line characters
+        "#{padding}#{wrapped_line}".gsub("\n", "\n#{padding}")
+      end.join("\n")
+    end
+
+    ##
+    # HACK: The "greatest_width" represents a terminal large enough to fit the
+    # content without text wrapping. This (*roughly) corresponds with the width
+    # of the longest line in the content.
+    # * There are edge cases due to the content being padded and colourized
+    #
+    # As the content length must be equal or greater than its longest line; the
+    # total length can be used as proxy. An additional terminal width is added
+    # to handle (*most) of the edge cases.
+    # * There still maybe a corner case when formatting a single paragraph
+    def greatest_width
+      content.length + width
+    end
+
+    def parse_markdown
+      # TTY::Markdown does not wrap text correctly and makes it difficult
+      # for WordWrap as it adds padding to the beginning of the lines.
+      #
+      # A work around is to pseudo disable text wrapping at this stage and then
+      # wrap each line individually accounting for its padding.
+      TTY::Markdown.parse(content, colors: colors, width: greatest_width)
+    rescue
+      if colors > 16
+        @colors = 16
+        retry       # Retry using 16-colors
+      end
+    end
+  end
+end

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '1.1.0-rc1'
+  VERSION = '1.1.0-rc2'
 end

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '1.0.0-c1'
+  VERSION = '1.2.0-rc1'
 end

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '1.2.0-rc1'
+  VERSION = '1.1.0-rc1'
 end

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '1.1.0-rc3'
+  VERSION = '1.1.0'
 end

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '1.1.0-rc2'
+  VERSION = '1.1.0-rc3'
 end

--- a/lib/patches/tty-markdown.rb
+++ b/lib/patches/tty-markdown.rb
@@ -1,0 +1,62 @@
+#==============================================================================
+# This patch has been ported from:
+# https://github.com/piotrmurach/tty-markdown/blob/93f6fe9096f3096d65dd3e752d9d873fd0f7acd6/lib/tty/markdown/converter.rb
+#
+# But modified to fit in with:
+# https://github.com/piotrmurach/tty-markdown/blob/v0.6.0/lib/tty/markdown/parser.rb
+#
+# The following license applies strictly to this file alone.
+# See LICENSE.txt for the main software license.
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Piotr Murach
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#==============================================================================
+
+require 'tty-markdown'
+require 'uri'
+
+module TTYMarkdownConverterPatch
+  def convert_a(el, opts)
+    if URI.parse(el.attr["href"]).class == URI::MailTo
+      el.attr["href"] = URI.parse(el.attr["href"]).to
+    end
+
+    if el.children.size == 1 && el.children[0].type == :text && el.children[0].value == el.attr["href"]
+
+      if !el.attr["title"].nil? && !el.attr["title"].strip.empty?
+        opts[:result] << "(#{el.attr["title"]}) "
+      end
+      opts[:result] << @pastel.decorate(el.attr["href"], *@theme[:link])
+
+    elsif el.children.size > 0  && (el.children[0].type != :text || !el.children[0].value.strip.empty?)
+      inner(el, opts)
+
+      opts[:result] << " #{TTY::Markdown.symbols[:arrow]} "
+      if el.attr["title"]
+        opts[:result] << "(#{el.attr["title"]}) "
+      end
+      opts[:result] << @pastel.decorate(el.attr["href"], *@theme[:link])
+    end
+  end
+end
+
+TTY::Markdown::Parser.prepend TTYMarkdownConverterPatch


### PR DESCRIPTION
This PR adds a new `info` command that renders the `metadata` contained within the template to the user. This is broadly based on the original `cluster template` command. The `metadata` syntax has changed slightly to make it easier to parse:

```
#@ flight_JOB[<key>]: <value>

e.g.
#@      flight_JOB[name]: Demo
#@      flight_JOB[desc]: A short summary of the demo script
#@ flight_JOB[copyright]: Copyright (C) 2020 Me Myself and I
#@   flight_JOB[license]: WTFPL
```

PS: Remember to bump the version to `1.1.0` and remove the -rcX suffix before merging