### PR TITLE
Add a script name and notes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,9 @@ GEM
       strings (~> 0.2.0)
       tty-color (~> 0.5)
       tty-screen (~> 0.8)
+    tty-pager (0.14.0)
+      strings (~> 0.2.0)
+      tty-screen (~> 0.8)
     tty-prompt (0.23.0)
       pastel (~> 0.8)
       tty-reader (~> 0.8)
@@ -108,6 +111,7 @@ DEPENDENCIES
   pry
   pry-byebug
   tty-markdown
+  tty-pager
   tty-prompt
   tty-table!
   word_wrap

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     strings-ansi (0.2.0)
     tty-color (0.6.0)
     tty-cursor (0.7.1)
+    tty-editor (0.6.0)
+      tty-prompt (~> 0.22)
     tty-markdown (0.7.0)
       kramdown (>= 1.16.2, < 3.0)
       pastel (~> 0.8)
@@ -110,6 +112,7 @@ DEPENDENCIES
   output_mode
   pry
   pry-byebug
+  tty-editor
   tty-markdown
   tty-pager
   tty-prompt

--- a/etc/flight-job.yaml
+++ b/etc/flight-job.yaml
@@ -86,6 +86,13 @@
 # minimum_terminal_width: 80
 
 # ==============================================================================
+# Maximum Standard Input Size
+# The maximum file size that will be provided to STDIN. The size must be given
+# in Bytes.
+# ==============================================================================
+# max_stdin_size: 1048576 # (1 MB)
+
+# ==============================================================================
 # Submission Period
 # The minimum amount of time to wait before a job that is "pending submission"
 # is considered failed.

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -90,6 +90,10 @@ module FlightJob
       c.summary = 'List your rendered scripts'
     end
 
+    create_command 'view-script', 'SCRIPT_ID' do |c|
+      c.summary = 'View the content of a script'
+    end
+
     create_command 'info-script', 'SCRIPT_ID' do |c|
       c.summary = 'Display details about a rendered script'
     end

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -120,6 +120,10 @@ module FlightJob
       c.summary = 'Rename a script given by its ID'
     end
 
+    create_command 'edit-script-notes', 'SCRIPT_ID' do |c|
+      c.summary = 'Open the script notes in the system editor'
+    end
+
     create_command 'delete-script', 'SCRIPT_ID' do |c|
       c.summary = 'Permanently remove a script'
     end

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -103,6 +103,15 @@ module FlightJob
       c.slop.bool '--stdin', 'Provide the answers via STDIN as JSON'
     end
 
+    # NOTE: This method signature is weird! I would expect it to be:
+    # rename-script OLD_SCRIPT_NAME, NEW_SCRIPT_NAME
+    #
+    # However this isn't possible as the "identity names" are not unique.
+    # Consider collapsing the ID and "identity_name" to be the same thing
+    create_command 'rename-script', 'SCRIPT_ID SCRIPT_NAME' do |c|
+      c.summary = 'Rename a script given by its ID'
+    end
+
     create_command 'delete-script', 'SCRIPT_ID' do |c|
       c.summary = 'Permanently remove a script'
     end

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -98,8 +98,7 @@ module FlightJob
       c.summary = 'Display details about a rendered script'
     end
 
-    # XXX: Consider making the method signature: TEMPLATE_NAME [SCRIPT_NAME]
-    create_command 'create-script', 'TEMPLATE_NAME' do |c|
+    create_command 'create-script', 'TEMPLATE_NAME [SCRIPT_NAME]' do |c|
       c.summary = 'Render a new script from a template'
       c.slop.bool '--stdin', 'Provide the answers via STDIN as JSON'
     end

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -100,7 +100,15 @@ module FlightJob
 
     create_command 'create-script', 'TEMPLATE_NAME [SCRIPT_NAME]' do |c|
       c.summary = 'Render a new script from a template'
-      c.slop.bool '--stdin', 'Provide the answers via STDIN as JSON'
+      c.slop.string '--answers', <<~MSG.chomp, meta: 'JSON|@filepath|@-'
+        Provide the answers as a JSON string.
+        Alternatively specify a file containing the answers with @filepath or STDIN as @-
+      MSG
+      c.slop.string '--notes', <<~MSG.chomp, meta: 'NOTES|@filepath|@-'
+        Provide additional information about the script
+        Alternatively specify a file containing the notes with @filepath or STDIN as @-
+      MSG
+      c.slop.bool '--stdin', 'Same as: "--answers @-"'
     end
 
     # NOTE: This method signature is weird! I would expect it to be:

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -37,8 +37,8 @@ module FlightJob
         answers = opts.stdin ? stdin_answers : prompt_answers
 
         # Render the script
-        script = Script.new(template_id: template.id, script_name: template.script_template_name)
-        script.render_and_save(**answers)
+        script = Script.new(template_id: template.id, script_name: template.script_template_name, answers: answers)
+        script.render_and_save
 
         # Render the script output
         puts Outputs::InfoScript.build_output(**output_options).render(script)

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -31,13 +31,19 @@ require 'tty-prompt'
 module FlightJob
   module Commands
     class CreateScript < Command
+      # TODO: Make me configurable
       MAX_STDIN_SIZE = 1*1024*1024
 
       def run
-        answers = opts.stdin ? stdin_answers : prompt_answers
+        answers = answers_input || prompt_answers
 
         # Render the script
-        script = Script.new(template_id: template.id, script_name: template.script_template_name, answers: answers)
+        script = Script.new(
+          template_id: template.id,
+          script_name: template.script_template_name,
+          answers: answers,
+          notes: notes_input
+        )
 
         # Apply the identity_name
         script.identity_name = args[1] if args.length > 1
@@ -60,19 +66,33 @@ module FlightJob
         end
       end
 
-      def stdin_answers
-        # TODO: Validate the correct answers have been provided
-        input = $stdin.read_nonblock(MAX_STDIN_SIZE)
-        if input.length == MAX_STDIN_SIZE
-          raise InputError, "The STDIN exceeds the maximum size of: #{MAX_STDIN_SIZE}B"
-        end
-        JSON.parse(input)
-      rescue Errno::EWOULDBLOCK, Errno::EWOULDBLOCK
-        raise InputError, "Failed to read the data from STDIN"
+      def answers_input
+        return unless opts.stdin || opts.answers
+        string = if opts.stdin || opts.answers == '@-'
+                   cached_stdin
+                 elsif opts.answers[0] == '@'
+                   read_file(opts.answers[1..])
+                 else
+                   opts.answers
+                 end
+        JSON.parse(string)
       rescue JSON::ParserError
-        raise InputError, 'The STDIN is not valid JSON!'
+        flag = opts.stdin ? '--stdin' : '--answers'
+        raise InputError, "The following input is not valid JSON: #{pastel.yellow flag}"
       end
 
+      def notes_input
+        return unless opts.notes
+        if opts.notes == '@-'
+          cached_stdin
+        elsif opts.notes[0] == '@'
+          read_file(opts.notes[1..])
+        else
+          opts.notes
+        end
+      end
+
+      # TODO: Error if not connected to a TTY
       def prompt_answers
         template.generation_questions.each_with_object({}) do |question, memo|
           if question.related_question_id
@@ -113,6 +133,27 @@ module FlightJob
 
       def prompt
         @prompt = TTY::Prompt.new(help_color: :yellow)
+      end
+
+      # Technically multiple flags may try and read STDIN. Whilst this would be an "unusual"
+      # use case, it is still "technically" valid. In this case STDIN becomes the input for
+      # both flags. However as the input can only be read once, it needs to be cached
+      def cached_stdin
+        @cached_stdin ||= $stdin.read_nonblock(MAX_STDIN_SIZE).tap do |str|
+          if str.length == MAX_STDIN_SIZE
+            raise InputError, "The STDIN exceeds the maximum size of: #{MAX_STDIN_SIZE}B"
+          end
+        end
+      rescue Errno::EWOULDBLOCK, Errno::EWOULDBLOCK
+        raise InputError, "Failed to read the data from STDIN"
+      end
+
+      def read_file(path)
+        if File.exists?(path)
+          File.read(path)
+        else
+          raise InputError, "Could not locate file: #{path}"
+        end
       end
     end
   end

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -32,9 +32,29 @@ module FlightJob
   module Commands
     class CreateScript < Command
       def run
-        answers = answers_input || prompt_answers
+        # Resolves the answers
+        answers = answers_input || begin
+          if $stdout.tty? && opts.notes == '@-'
+            msg = <<~WARN.chomp
+              Can not prompt for the answers as Standard Input is in use!
+              Proceeding with the defaults.
+            WARN
+            $stderr.puts pastel.red(msg)
+            FlightJob.logger.warn msg
+            {}
+          elsif $stdout.tty?
+            prompt_answers
+          else
+            msg = <<~WARN.chomp
+              No answers have been provided! Proceeding with the defaults.
+            WARN
+            $stderr.puts pastel.red(msg)
+            FlightJob.logger.warn msg
+            {}
+          end
+        end
 
-        # Render the script
+        # Create the script object
         script = Script.new(
           template_id: template.id,
           script_name: template.script_template_name,
@@ -63,6 +83,17 @@ module FlightJob
         end
       end
 
+      def notes_input
+        return unless opts.notes
+        if opts.notes == '@-'
+          cached_stdin
+        elsif opts.notes[0] == '@'
+          read_file(opts.notes[1..])
+        else
+          opts.notes
+        end
+      end
+
       def answers_input
         return unless opts.stdin || opts.answers
         string = if opts.stdin || opts.answers == '@-'
@@ -78,18 +109,6 @@ module FlightJob
         raise InputError, "The following input is not valid JSON: #{pastel.yellow flag}"
       end
 
-      def notes_input
-        return unless opts.notes
-        if opts.notes == '@-'
-          cached_stdin
-        elsif opts.notes[0] == '@'
-          read_file(opts.notes[1..])
-        else
-          opts.notes
-        end
-      end
-
-      # TODO: Error if not connected to a TTY
       def prompt_answers
         template.generation_questions.each_with_object({}) do |question, memo|
           if question.related_question_id
@@ -141,8 +160,8 @@ module FlightJob
             raise InputError, "The STDIN exceeds the maximum size of: #{FlightJob.config.max_stdin_size}B"
           end
         end
-      rescue Errno::EWOULDBLOCK, Errno::EWOULDBLOCK
-        raise InputError, "Failed to read the data from STDIN"
+      rescue Errno::EWOULDBLOCK, EOFError
+        raise InputError, "Failed to read the data from the Standard Input"
       end
 
       def read_file(path)

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -31,9 +31,6 @@ require 'tty-prompt'
 module FlightJob
   module Commands
     class CreateScript < Command
-      # TODO: Make me configurable
-      MAX_STDIN_SIZE = 1*1024*1024
-
       def run
         answers = answers_input || prompt_answers
 
@@ -139,9 +136,9 @@ module FlightJob
       # use case, it is still "technically" valid. In this case STDIN becomes the input for
       # both flags. However as the input can only be read once, it needs to be cached
       def cached_stdin
-        @cached_stdin ||= $stdin.read_nonblock(MAX_STDIN_SIZE).tap do |str|
-          if str.length == MAX_STDIN_SIZE
-            raise InputError, "The STDIN exceeds the maximum size of: #{MAX_STDIN_SIZE}B"
+        @cached_stdin ||= $stdin.read_nonblock(FlightJob.config.max_stdin_size).tap do |str|
+          if str.length == FlightJob.config.max_stdin_size
+            raise InputError, "The STDIN exceeds the maximum size of: #{FlightJob.config.max_stdin_size}B"
           end
         end
       rescue Errno::EWOULDBLOCK, Errno::EWOULDBLOCK

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -38,6 +38,11 @@ module FlightJob
 
         # Render the script
         script = Script.new(template_id: template.id, script_name: template.script_template_name, answers: answers)
+
+        # Apply the identity_name
+        script.identity_name = args[1] if args.length > 1
+
+        # Save the script
         script.render_and_save
 
         # Render the script output

--- a/lib/flight_job/commands/edit_script_notes.rb
+++ b/lib/flight_job/commands/edit_script_notes.rb
@@ -1,6 +1,5 @@
-# frozen_string_literal: true
 #==============================================================================
-# Copyright (C) 2020-present Alces Flight Ltd.
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
 # This file is part of Flight Job.
 #
@@ -25,21 +24,27 @@
 # For more information on Flight Job, please visit:
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
-source 'https://rubygems.org'
 
-gem 'commander-openflighthpc', '~> 2.1'
-gem 'activemodel'
-gem 'flight_configuration', github: 'openflighthpc/flight_configuration', branch: '85905e36d2db793587bf10b17734a36b6e9197f2'
-gem 'json_schemer'
-gem 'output_mode'
-gem 'tty-markdown'
-gem 'tty-editor'
-gem 'tty-table', github: 'openflighthpc/tty-table', branch: '9b326fcbe04968463da58c000fbb1dd5ce178243'
-gem 'tty-prompt'
-gem 'tty-pager'
-gem 'word_wrap'
+require 'tty-editor'
 
-group :development do
-  gem 'pry'
-  gem 'pry-byebug'
+module FlightJob
+  module Commands
+    class EditScriptNotes < Command
+      def run
+        # Ensure the script exists up front
+        script = load_script(args.first)
+
+        cmd = TTY::Editor.from_env.first || begin
+          $stderr.puts pastel.red <<~WARN.chomp
+            Defaulting to 'vi' as the editor.
+            This can be changed by setting the EDITOR environment variable.
+          WARN
+          'vi'
+        end
+
+        # Open the file
+        TTY::Editor.open(script.notes_path, command: cmd)
+      end
+    end
+  end
 end

--- a/lib/flight_job/commands/rename_script.rb
+++ b/lib/flight_job/commands/rename_script.rb
@@ -1,0 +1,50 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+module FlightJob
+  module Commands
+    class RenameScript < Command
+      def run
+        script = load_script(args.first)
+        script.identity_name = args[1]
+
+        # Ensure the script is still valid
+        # NOTE: Currently this should not fail, however this may change in the future.
+        # Particularly if the ID and identity_name are collapsed together, TBA
+        unless script.valid?
+          raise InputError, "'#{args[1]}' is not a valid script name"
+        end
+
+        # Save the new metadata
+        script.save_metadata
+
+        # Emit the new info
+        puts Outputs::InfoScript.build_output(**output_options).render(script)
+      end
+    end
+  end
+end

--- a/lib/flight_job/commands/view_script.rb
+++ b/lib/flight_job/commands/view_script.rb
@@ -1,5 +1,5 @@
 #==============================================================================
-# Copyright (C) 2020-present Alces Flight Ltd.
+# Copyright (C) 2021-present Alces Flight Ltd.
 #
 # This file is part of Flight Job.
 #

--- a/lib/flight_job/commands/view_script.rb
+++ b/lib/flight_job/commands/view_script.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 #==============================================================================
 # Copyright (C) 2020-present Alces Flight Ltd.
 #
@@ -25,20 +24,19 @@
 # For more information on Flight Job, please visit:
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
-source 'https://rubygems.org'
 
-gem 'commander-openflighthpc', '~> 2.1'
-gem 'activemodel'
-gem 'flight_configuration', github: 'openflighthpc/flight_configuration', branch: '85905e36d2db793587bf10b17734a36b6e9197f2'
-gem 'json_schemer'
-gem 'output_mode'
-gem 'tty-markdown'
-gem 'tty-table', github: 'openflighthpc/tty-table', branch: '9b326fcbe04968463da58c000fbb1dd5ce178243'
-gem 'tty-prompt'
-gem 'tty-pager'
-gem 'word_wrap'
+require 'tty-pager'
 
-group :development do
-  gem 'pry'
-  gem 'pry-byebug'
+module FlightJob
+  module Commands
+    class ViewScript < Command
+      def run
+        TTY::Pager.new(commnad: 'less -SFRX').page(File.read script.script_path)
+      end
+
+      def script
+        @script ||= load_script(args.first)
+      end
+    end
+  end
 end

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -62,6 +62,7 @@ module FlightJob
     attribute :minimum_terminal_width, default: 80
     attribute :check_cron, default: 'libexec/check-cron.sh',
               transform: relative_to(root_path)
+    attribute :max_stdin_size, default: 1048576
     attribute :log_path, required: false,
               default: '~/.cache/flight/log/share/job.log',
               transform: ->(path) do

--- a/lib/flight_job/help_formatter.rb
+++ b/lib/flight_job/help_formatter.rb
@@ -103,7 +103,7 @@ module FlightJob
     end
 
     def command_prefix_order
-      @command_prefix_order ||= ['list', 'create', 'submit', 'show', 'info', 'rename', 'delete']
+      @command_prefix_order ||= ['list', 'create', 'submit', 'info', 'view', 'edit', 'rename', 'delete']
     end
 
     def commands_by_section

--- a/lib/flight_job/help_formatter.rb
+++ b/lib/flight_job/help_formatter.rb
@@ -103,7 +103,7 @@ module FlightJob
     end
 
     def command_prefix_order
-      @command_prefix_order ||= ['list', 'create', 'submit', 'show', 'info', 'delete']
+      @command_prefix_order ||= ['list', 'create', 'submit', 'show', 'info', 'rename', 'delete']
     end
 
     def commands_by_section

--- a/lib/flight_job/help_formatter.rb
+++ b/lib/flight_job/help_formatter.rb
@@ -97,7 +97,7 @@ module FlightJob
     def sections
       @sections ||= {
         ['template', 'templates'] => 'Templates:',
-        ['script', 'scripts'] => 'Scripts:',
+        ['script', 'scripts', 'script-notes'] => 'Scripts:',
         ['job', 'jobs'] => 'Jobs:'
       }
     end

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -41,6 +41,7 @@ module FlightJob
         'created_at' => { 'type' => 'string', 'format' => 'date-time' },
         'template_id' => { 'type' => 'string' },
         'script_name' => { 'type' => 'string' },
+        'identity_name' => { 'type' => 'string' },
         'answers' => { 'type' => 'object' }
       }
     })
@@ -181,11 +182,11 @@ module FlightJob
     # 1. It is not guaranteed to be unique,
     # 2. How it is being set is still volatile
     def identity_name
-      @identity_name || answers['job_name'] || script_name
+      metadata['identity_name'] || answers['job_name'] || script_name
     end
 
     def identity_name=(name)
-      @identity_name ||= name
+      metadata['identity_name'] = name
     end
 
     # NOTE: For backwards compatibility, the 'answers' are not strictly required

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -167,6 +167,7 @@ module FlightJob
       metadata['template_id'] = id
     end
 
+    # NOTE: This is a misnomer, it is actually the filename of the script
     def script_name
       metadata['script_name']
     end
@@ -174,6 +175,17 @@ module FlightJob
     def script_name=(name)
       @script_path = nil
       metadata['script_name'] = name
+    end
+
+    # This is the name used in the user facing interfaces, note:
+    # 1. It is not guaranteed to be unique,
+    # 2. How it is being set is still volatile
+    def identity_name
+      @identity_name || answers['job_name'] || script_name
+    end
+
+    def identity_name=(name)
+      @identity_name ||= name
     end
 
     # NOTE: For backwards compatibility, the 'answers' are not strictly required
@@ -225,6 +237,7 @@ module FlightJob
       answers # Ensure the answers have been set
       {
         "id" => id,
+        "identity_name" => identity_name,
         "path" => script_path
       }.merge(metadata)
     end

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -225,12 +225,14 @@ module FlightJob
       content = render
 
       # Writes the data to disk
-      FileUtils.mkdir_p File.dirname(metadata_path)
-      File.write(metadata_path, YAML.dump(metadata))
+      save_metadata
       File.write(script_path, content)
-
-      # Makes the script executable and metadata read/write
       FileUtils.chmod(0700, script_path)
+    end
+
+    def save_metadata
+      FileUtils.mkdir_p File.dirname(metadata_path)
+      File.write metadata_path, YAML.dump(metadata)
       FileUtils.chmod(0600, metadata_path)
     end
 

--- a/lib/flight_job/outputs/info_script.rb
+++ b/lib/flight_job/outputs/info_script.rb
@@ -32,8 +32,10 @@ module FlightJob
     extend OutputMode::TLDR::Show
 
     register_attribute(header: 'ID') { |s| s.id }
+    # NOTE: The verbose output is at the end to avoid the order changing
+    register_attribute(header: 'Name', verbose: false) { |s| s.identity_name }
     register_attribute(header: 'Template ID') { |s| s.template_id }
-    register_attribute(header: 'Name') { |s| s.script_name }
+    register_attribute(header: 'File Name') { |s| s.script_name }
     register_attribute(header: 'Path') { |s| s.script_path }
 
     # Toggle the format of the created at time
@@ -41,6 +43,9 @@ module FlightJob
     register_attribute(header: 'Created At', verbose: false) do |script|
       DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
     end
+
+    # NOTE: The following is at the end to preserve the order of the verbose output
+    register_attribute(header: 'Name', verbose: true) { |s| s.identity_name }
 
     def self.build_output(**opts)
       if opts.delete(:json)

--- a/lib/flight_job/outputs/list_scripts.rb
+++ b/lib/flight_job/outputs/list_scripts.rb
@@ -32,8 +32,10 @@ module FlightJob
     extend OutputMode::TLDR::Index
 
     register_column(header: 'ID', row_color: :yellow) { |s| s.id }
+    # NOTE: The verbose output is at the end to avoid the order changing
+    register_column(header: 'Name', verbose: false) { |s| s.identity_name }
     register_column(header: 'Template ID') { |s| s.template_id }
-    register_column(header: 'Name') { |s| s.script_name }
+    register_column(header: 'File Name') { |s| s.script_name }
 
     # Toggle the format of the created at time
     register_column(header: 'Created At', verbose: true) { |s| s.created_at }
@@ -42,6 +44,9 @@ module FlightJob
     end
 
     register_column(header: 'Path', verbose: true) { |s| s.script_path }
+
+    # NOTE: The following is at the end to preserve the order of the verbose output
+    register_column(header: 'Name', verbose: true) { |s| s.identity_name }
 
     def self.build_output(**opts)
       if opts.delete(:json)

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
A new "script name" has been added, which can be optionally set on create:

```
bin/job create template script-name
```

This has introduced a few interesting problems:
1. The `script_name` in the metadata refers to the "file name",
2. The public "script name" is stored as the `identity_name` in the metadata, and
3. The `templates` commonly ask for the `job_name`.

This is a bit of a mess and probably needs streamlining. The "script name"/`identity_name` will fallback onto the `job_name` and original `script_name`/"filename" if not set.

Also the "script name"/`identity_name` can not be used to identify the scripts as it is not unique. It might be worth merging it with the `ID`.

---

There is now a new `notes` feature that are stored along side the script. These can be provided on `create` as:
* `--notes STRING`: A literal note about the script,
* `--notes @file`: A file containing the notes
* `--notes @-`: Get the notes from standard input.

A similar change has been made for the answers, so they can be provided as:

* `--answers JSON`: The literal answers given as JSON,
* `--answers @file`: A file containing the answers,
* `--answers @-`: Get the answers from standard input, or
* `--stdin`: Same as `--answers @-` 

Obviously it does not make much sense to get the `notes` and `answers` both from standard in, however I was forced to compromise between:
1. Breaking consistency and only allow one to come from STDIN,
2. Treat it as "technically valid" and assume it won't be used in practice.

I went with option 2 in this case. If `--notes @- --answer @-` is specified, then the answers will be saved as the `notes` :man_shrugging:.

Getting the `notes` from standard in also disables the prompt for the answers. As the prompt would otherwise try and read the input from the `notes` file.