### PR TITLE
Tweak output rendering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       rexml
     method_source (1.0.0)
     minitest (5.14.4)
-    output_mode (1.4.0)
+    output_mode (1.5.0)
       pastel (>= 0.7)
       tty-color (>= 0.5)
       tty-table (>= 0.11)

--- a/lib/flight_job.rb
+++ b/lib/flight_job.rb
@@ -36,20 +36,20 @@ module FlightJob
 
   # Setup the autoloads for the commands
   module Commands
-    Dir.glob(File.expand_path('flight_job/commands/*', __dir__)).each do |path|
+    Dir.glob(File.expand_path('flight_job/commands/*.rb', __dir__)).each do |path|
       autoload FlightJob.constantize(File.basename(path, '.*')), path
     end
   end
 
   # Setup the autoloads for models
-  Dir.glob(File.expand_path('flight_job/models/*', __dir__)).each do |path|
+  Dir.glob(File.expand_path('flight_job/models/*.rb', __dir__)).each do |path|
     autoload FlightJob.constantize(File.basename(path, '.*')), path
   end
 
   # Setup the autoloads for outputs
   autoload(:JSONRenderer, File.expand_path('flight_job/json_renderer', __dir__))
   module Outputs
-    Dir.glob(File.expand_path('flight_job/outputs/*', __dir__)).each do |path|
+    Dir.glob(File.expand_path('flight_job/outputs/*.rb', __dir__)).each do |path|
       autoload FlightJob.constantize(File.basename(path, '.*')), path
     end
   end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -331,7 +331,7 @@ module FlightJob
             self.start_time = nil
           else
             begin
-              self.start_time = DateTime.parse(data['start_time']).rfc3339
+              self.start_time = Time.parse(data['start_time']).to_datetime.rfc3339
             rescue ArgumentError
               FlightJob.logger.error "Failed to parse start_time: #{data['start_time']}"
               FlightJob.logger.debug $!.full_message
@@ -344,7 +344,7 @@ module FlightJob
             self.end_time = nil
           else
             begin
-              self.end_time = DateTime.parse(data['end_time']).rfc3339
+              self.end_time = Time.parse(data['end_time']).to_datetime.rfc3339
             rescue ArgumentError
               FlightJob.logger.error "Failed to parse end_time: #{data['end_time']}"
               FlightJob.logger.debug $!.full_message

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -326,7 +326,6 @@ module FlightJob
         process_output('monitor', status, stdout) do |data|
           self.state = data['state']
 
-          # Update the start_time
           if ['', nil].include? data['start_time']
             self.start_time = nil
           else
@@ -339,8 +338,11 @@ module FlightJob
             end
           end
 
-          # Update the end_time
-          if ['', nil].include? data['end_time']
+          # For jobs in a non-terminal state, the slurm monitor reports the
+          # "expected end time" as the "actual end time".  Dealing with this
+          # issue here is the simplest fix, but ideally the monitor would
+          # separate expected and actual end times.
+          if ['', nil].include?(data['end_time']) || !TERMINAL_STATES.include?(state)
             self.end_time = nil
           else
             begin

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -33,37 +33,35 @@ module FlightJob
 
     TEMPLATE = <<~ERB
       <%
-        verbose = output.procs.any?(&:verbose?)
-        attrs = []
-        stdout = nil
-        stdout_padding = nil
-        each(:main) do |value, field:, padding:, **_|
-          if field == 'StdOut Path'
-            stdout = value
-            stdout_padding = padding
-          elsif field == 'StdErr Path'
-            if !verbose && value == stdout
-              attrs << [value, { field: 'Output Path', padding: stdout_padding }]
-            else
-              attrs << [stdout, { field: 'StdOut Path', padding: stdout_padding }]
-              attrs << [value, { field: 'StdErr Path', padding: padding }]
-            end
-          else
-            attrs << [value, { field: field, padding: padding }]
-          end
+        verbose = output.context[:verbose]
+        main = output.callables.config_select(:section, :main)
+        paths = main.select(&:paths?)
+
+        # Determine if the STDOUT/STDERR paths should be combined or
+        # independently displayed
+        if verbose || paths.map { |p| p.call(model) }.uniq.length != 1
+          callables = OutputMode::Callables.new main.reject(&:combined?)
+        else
+          callables = OutputMode::Callables.new main.reject(&:paths?)
         end
       -%>
-      <% attrs.each do |value, field:, padding:| -%>
-      <%= padding -%><%= pastel.blue.bold field -%><%= pastel.bold ':' -%> <%= pastel.green value %>
+      <% callables.pad_each do |callable, padding:| -%>
+      <%
+          # Generates the value
+          # NOTE: The output contains details about how to handle nil/true/false
+          value = pastel.green callable.generator(output).call(model)
+          header = pastel.blue.bold callable.config[:header]
+      -%>
+      <%= padding -%><%= header -%><%= pastel.bold ':' -%> <%= value %>
       <% end -%>
       <%
         submit_outputs = output.procs.select { |proc| proc.config[:section] == :submit }
-        unless submit_outputs.empty?
+        if verbose || output.context[:submit]
       -%>
 
-      <%= pastel.blue.bold "Submit Standard Out" -%><%= pastel.bold ':' %>
+      <%= pastel.blue.bold "Submit Std. Out" -%><%= pastel.bold ':' %>
       <%= pastel.green submit_outputs.first.call(model) %>
-      <%= pastel.blue.bold "Submit Standard Error" -%><%= pastel.bold ':' %>
+      <%= pastel.blue.bold "Submit Std. Error" -%><%= pastel.bold ':' %>
       <%= pastel.green submit_outputs.last.call(model) %>
       <% end -%>
     ERB
@@ -78,36 +76,49 @@ module FlightJob
     # NOTE: There is a rendering issue of integers into the TSV output. Needs investigation
     register_attribute(section: :main, header: 'Submit Status', verbose: true) { |j| j.submit_status.to_s }
 
-    # Toggle the format of the created at time
-    register_attribute(section: :main, header: 'Created at', verbose: true) { |j| j.created_at }
-    register_attribute(section: :main, header: 'Created at', verbose: false) do |job|
-      DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
+    register_attribute(header: 'Created at') do |job, verbose:|
+      if verbose
+        job.created_at
+      else
+        DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
+      end
     end
 
     # NOTE: These could be the predicted times instead of the actual, consider
     # delineating the two
-    register_attribute(section: :main, header: 'Start at', verbose: true) { |j| j.start_time }
-    register_attribute(section: :main, header: 'Start at', verbose: false) do |job|
-      next nil unless job.start_time
-      DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
+    register_attribute(header: 'Started at') do |job, verbose:|
+      if job.start_time.nil?
+        nil
+      elsif verbose
+        job.start_time
+      else
+        DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
+      end
     end
-    register_attribute(section: :main, header: 'End at', verbose: true) { |j| j.end_time }
-    register_attribute(section: :main, header: 'End at', verbose: false) do |job|
-      next nil unless job.end_time
-      DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
+    register_attribute(header: 'Ended at') do |job, verbose:|
+      if job.end_time.nil?
+        nil
+      elsif verbose
+        job.end_time
+      else
+        DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
+      end
     end
 
-    # NOTE: The 'StdOut Path' header must be exactly the same length as the 'Output Path' header
-    #       This allows the header to be toggled without affecting the padding
-    # NOTE: Remember to update the Template if the STDOUT/STDERR header changes
-    #       Failure to do so will break the rendering
-    register_attribute(section: :main, header: 'StdOut Path') { |j| j.stdout_path }
-    register_attribute(section: :main, header: 'StdErr Path') { |j| j.stderr_path }
+    # NOTE: In interactive shells, the STDOUT/STDERR are merged together if they
+    #       are the same. The 'modes' are boolean flags (similar to verbose/interactive)
+    #       which are used to select the appropriate attributes.
+    #
+    #       As each attribute is defined independently, the headers can be changed without
+    #       affecting the ability to pad the output.
+    register_attribute(section: :main, modes: [:paths], header: 'Std. Out Path') { |j| j.stdout_path }
+    register_attribute(section: :main, modes: [:paths], header: 'Std. Error Path') { |j| j.stderr_path }
+    register_attribute(section: :main, interactive: true, modes: [:combined], header: 'Output Path') { |j| j.stdout_path }
 
-    register_attribute(section: :submit, header: 'Submission STDOUT') do |job|
+    register_attribute(section: :submit, header: 'noop') do |job|
       job.submit_stdout
     end
-    register_attribute(section: :submit, header: 'Submission STOUT') do |job|
+    register_attribute(section: :submit, header: 'noop') do |job|
       job.submit_stderr
     end
 
@@ -116,20 +127,7 @@ module FlightJob
       if opts.delete(:json)
         JSONRenderer.new(false, opts[:interactive])
       else
-        super(template: TEMPLATE, **opts).tap do |output|
-          # OutputMode currently doesn't properly support escaping of the newlines
-          # due to how it has wrapped the underlying CSV library
-          case output
-          when OutputMode::Outputs::Delimited
-            output.config.merge! write_converters: [->(f) { f.to_s.dump.sub(/\A"/, '').sub(/"\Z/, '') }]
-
-          # Toggles the STDOUT/STDERR display based on verbosity or if explicitly flagged
-          when OutputMode::Outputs::Templated
-            if !(opts[:verbose] || submit)
-              output.procs.reject! { |c| c.config[:section] == :submit }
-            end
-          end
-        end
+        super(template: TEMPLATE, context: { submit: submit }, **opts)
       end
     end
   end

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -68,7 +68,7 @@ module FlightJob
 
     register_attribute(section: :main, header: 'ID') { |j| j.id }
     register_attribute(section: :main, header: 'Script ID') { |j| j.script_id }
-    register_attribute(section: :main, header: 'Alt. ID') { |j| j.scheduler_id }
+    register_attribute(section: :main, header: 'Sched. ID') { |j| j.scheduler_id }
     register_attribute(section: :main, header: 'State') { |j| j.state }
 
     # Show a boolean in the "simplified" output, and the exit code in the verbose
@@ -76,7 +76,7 @@ module FlightJob
     # NOTE: There is a rendering issue of integers into the TSV output. Needs investigation
     register_attribute(section: :main, header: 'Submit Status', verbose: true) { |j| j.submit_status.to_s }
 
-    register_attribute(header: 'Created at') do |job, verbose:|
+    register_attribute(section: :main, header: 'Created at') do |job, verbose:|
       if verbose
         job.created_at
       else
@@ -86,7 +86,7 @@ module FlightJob
 
     # NOTE: These could be the predicted times instead of the actual, consider
     # delineating the two
-    register_attribute(header: 'Started at') do |job, verbose:|
+    register_attribute(section: :main, header: 'Started at') do |job, verbose:|
       if job.start_time.nil?
         nil
       elsif verbose
@@ -95,7 +95,7 @@ module FlightJob
         DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
       end
     end
-    register_attribute(header: 'Ended at') do |job, verbose:|
+    register_attribute(section: :main, header: 'Ended at') do |job, verbose:|
       if job.end_time.nil?
         nil
       elsif verbose

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -59,16 +59,16 @@ module FlightJob
         if verbose || output.context[:submit]
       -%>
 
-      <%= pastel.blue.bold "Submit Std. Out" -%><%= pastel.bold ':' %>
+      <%= pastel.blue.bold "Submit Stdout" -%><%= pastel.bold ':' %>
       <%= pastel.green submit_outputs.first.call(model) %>
-      <%= pastel.blue.bold "Submit Std. Error" -%><%= pastel.bold ':' %>
+      <%= pastel.blue.bold "Submit Stderr" -%><%= pastel.bold ':' %>
       <%= pastel.green submit_outputs.last.call(model) %>
       <% end -%>
     ERB
 
     register_attribute(section: :main, header: 'ID') { |j| j.id }
     register_attribute(section: :main, header: 'Script ID') { |j| j.script_id }
-    register_attribute(section: :main, header: 'Sched. ID') { |j| j.scheduler_id }
+    register_attribute(section: :main, header: 'Scheduler ID') { |j| j.scheduler_id }
     register_attribute(section: :main, header: 'State') { |j| j.state }
 
     # Show a boolean in the "simplified" output, and the exit code in the verbose
@@ -111,8 +111,8 @@ module FlightJob
     #
     #       As each attribute is defined independently, the headers can be changed without
     #       affecting the ability to pad the output.
-    register_attribute(section: :main, modes: [:paths], header: 'Std. Out Path') { |j| j.stdout_path }
-    register_attribute(section: :main, modes: [:paths], header: 'Std. Error Path') { |j| j.stderr_path }
+    register_attribute(section: :main, modes: [:paths], header: 'Stdout Path') { |j| j.stdout_path }
+    register_attribute(section: :main, modes: [:paths], header: 'Stderr Path') { |j| j.stderr_path }
     register_attribute(section: :main, interactive: true, modes: [:combined], header: 'Output Path') { |j| j.stdout_path }
 
     register_attribute(section: :submit, header: 'noop') do |job|

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -58,20 +58,20 @@ module FlightJob
     register_attribute(section: :main, header: 'Submit Status', verbose: true) { |j| j.submit_status.to_s }
 
     # Toggle the format of the created at time
-    register_attribute(section: :main, header: 'Created At', verbose: true) { |j| j.created_at }
-    register_attribute(section: :main, header: 'Created At', verbose: false) do |job|
+    register_attribute(section: :main, header: 'Created at', verbose: true) { |j| j.created_at }
+    register_attribute(section: :main, header: 'Created at', verbose: false) do |job|
       DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
     end
 
     # NOTE: These could be the predicted times instead of the actual, consider
     # delineating the two
-    register_attribute(section: :main, header: 'Start Time', verbose: true) { |j| j.start_time }
-    register_attribute(section: :main, header: 'Start Time', verbose: false) do |job|
+    register_attribute(section: :main, header: 'Start at', verbose: true) { |j| j.start_time }
+    register_attribute(section: :main, header: 'Start at', verbose: false) do |job|
       next nil unless job.start_time
       DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
     end
-    register_attribute(section: :main, header: 'End Time', verbose: true) { |j| j.end_time }
-    register_attribute(section: :main, header: 'End Time', verbose: false) do |job|
+    register_attribute(section: :main, header: 'End at', verbose: true) { |j| j.end_time }
+    register_attribute(section: :main, header: 'End at', verbose: false) do |job|
       next nil unless job.end_time
       DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
     end

--- a/lib/flight_job/outputs/info_script.rb
+++ b/lib/flight_job/outputs/info_script.rb
@@ -49,8 +49,8 @@ module FlightJob
     register_attribute(section: :main, header: 'Path') { |s| s.script_path }
 
     # Toggle the format of the created at time
-    register_attribute(section: :main, header: 'Created At', verbose: true) { |s| s.created_at }
-    register_attribute(section: :main, header: 'Created At', verbose: false) do |script|
+    register_attribute(section: :main, header: 'Created at', verbose: true) { |s| s.created_at }
+    register_attribute(section: :main, header: 'Created at', verbose: false) do |script|
       DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
     end
 

--- a/lib/flight_job/outputs/info_script.rb
+++ b/lib/flight_job/outputs/info_script.rb
@@ -48,10 +48,12 @@ module FlightJob
     register_attribute(section: :main, header: 'File Name') { |s| s.script_name }
     register_attribute(section: :main, header: 'Path') { |s| s.script_path }
 
-    # Toggle the format of the created at time
-    register_attribute(section: :main, header: 'Created at', verbose: true) { |s| s.created_at }
-    register_attribute(section: :main, header: 'Created at', verbose: false) do |script|
-      DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
+    register_attribute(header: 'Created at') do |script, verbose:|
+      if verbose
+        script.created_at
+      else
+        DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
+      end
     end
 
     register_attribute(section: :notes, header: 'Notes') { |s| s.notes }
@@ -60,12 +62,7 @@ module FlightJob
       if opts.delete(:json)
         JSONRenderer.new(false, opts[:interactive])
       else
-        super(template: TEMPLATE, **opts).tap do |output|
-          case output
-          when OutputMode::Outputs::Delimited
-            output.config.merge! write_converters: [->(f) { f.to_s.dump.sub(/\A"/, '').sub(/"\Z/, '') }]
-          end
-        end
+        super(template: TEMPLATE, **opts)
       end
     end
   end

--- a/lib/flight_job/outputs/info_script.rb
+++ b/lib/flight_job/outputs/info_script.rb
@@ -48,7 +48,7 @@ module FlightJob
     register_attribute(section: :main, header: 'File Name') { |s| s.script_name }
     register_attribute(section: :main, header: 'Path') { |s| s.script_path }
 
-    register_attribute(header: 'Created at') do |script, verbose:|
+    register_attribute(section: :main, header: 'Created at') do |script, verbose:|
       if verbose
         script.created_at
       else

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -38,26 +38,37 @@ module FlightJob
     register_column(header: 'State') { |j| j.state }
 
     # Show a boolean in the "simplified" output, and the exit code in the verbose
+    # NOTE: The headers are intentionally toggled between outputs
     register_column(header: 'Submitted', verbose: false) { |j| j.submit_status == 0 }
     register_column(header: 'Submit Status', verbose: true) { |j| j.submit_status }
 
-    # Toggle the format of the created at time
-    register_column(header: 'Created at', verbose: true) { |j| j.created_at }
-    register_column(header: 'Created at', verbose: false) do |job|
-      DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
+    register_column(header: 'Created at') do |job, verbose:|
+      if verbose
+        job.created_at
+      else
+        DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
+      end
     end
 
     # NOTE: These could be the predicted times instead of the actual, consider
     # delineating the two
-    register_column(header: 'Started at', verbose: true) { |j| j.start_time }
-    register_column(header: 'Started at', verbose: false) do |job|
-      next nil unless job.start_time
-      DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
+    register_column(header: 'Started at') do |job, verbose:|
+      if job.start_time.nil?
+        nil
+      elsif verbose
+        job.start_time
+      else
+        DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
+      end
     end
-    register_column(header: 'Ended at', verbose: true) { |j| j.end_time }
-    register_column(header: 'Ended at', verbose: false) do |job|
-      next nil unless job.end_time
-      DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
+    register_column(header: 'Ended at') do |job, verbose:|
+      if job.end_time.nil?
+        nil
+      elsif verbose
+        job.end_time
+      else
+        DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
+      end
     end
 
     register_column(header: 'StdOut Path', verbose: true) { |j| j.stdout_path }
@@ -67,12 +78,7 @@ module FlightJob
       if opts.delete(:json)
         JSONRenderer.new(true, opts[:interactive])
       else
-        super(row_color: :cyan, header_color: :bold, **opts).tap do |output|
-          # NOTE: The rotate flag "hopefully" going to be a new feature to TTY::Table
-          # that stops is rotating in small terminals. OutputMode has no concept of this
-          # feature, currently
-          output.config.merge!(rotate: false) if output.is_a? OutputMode::Outputs::Tabulated
-        end
+        super(row_color: :cyan, header_color: :bold, **opts)
       end
     end
   end

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -42,20 +42,20 @@ module FlightJob
     register_column(header: 'Submit Status', verbose: true) { |j| j.submit_status }
 
     # Toggle the format of the created at time
-    register_column(header: 'Created At', verbose: true) { |j| j.created_at }
-    register_column(header: 'Created At', verbose: false) do |job|
+    register_column(header: 'Created at', verbose: true) { |j| j.created_at }
+    register_column(header: 'Created at', verbose: false) do |job|
       DateTime.rfc3339(job.created_at).strftime('%d/%m/%y %H:%M')
     end
 
     # NOTE: These could be the predicted times instead of the actual, consider
     # delineating the two
-    register_column(header: 'Start Time', verbose: true) { |j| j.start_time }
-    register_column(header: 'Start Time', verbose: false) do |job|
+    register_column(header: 'Started at', verbose: true) { |j| j.start_time }
+    register_column(header: 'Started at', verbose: false) do |job|
       next nil unless job.start_time
       DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
     end
-    register_column(header: 'End Time', verbose: true) { |j| j.end_time }
-    register_column(header: 'End Time', verbose: false) do |job|
+    register_column(header: 'Ended at', verbose: true) { |j| j.end_time }
+    register_column(header: 'Ended at', verbose: false) do |job|
       next nil unless job.end_time
       DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
     end

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -34,7 +34,7 @@ module FlightJob
 
     register_column(header: 'ID', row_color: :yellow) { |s| s.id }
     register_column(header: 'Script ID', verbose: true) { |j| j.script_id }
-    register_column(header: 'Alt. ID', verbose: true) { |j| j.scheduler_id }
+    register_column(header: 'Sched. ID', verbose: true) { |j| j.scheduler_id }
     register_column(header: 'State') { |j| j.state }
 
     # Show a boolean in the "simplified" output, and the exit code in the verbose

--- a/lib/flight_job/outputs/list_scripts.rb
+++ b/lib/flight_job/outputs/list_scripts.rb
@@ -35,10 +35,12 @@ module FlightJob
     register_column(header: 'Template ID') { |s| s.template_id }
     register_column(header: 'File Name') { |s| s.script_name }
 
-    # Toggle the format of the created at time
-    register_column(header: 'Created at', verbose: true) { |s| s.created_at }
-    register_column(header: 'Created at', verbose: false) do |script|
-      DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
+    register_column(header: 'Created at') do |script, verbose:|
+      if verbose
+        script.created_at
+      else
+        DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
+      end
     end
 
     register_column(header: 'Path', verbose: true) { |s| s.script_path }

--- a/lib/flight_job/outputs/list_scripts.rb
+++ b/lib/flight_job/outputs/list_scripts.rb
@@ -36,8 +36,8 @@ module FlightJob
     register_column(header: 'File Name') { |s| s.script_name }
 
     # Toggle the format of the created at time
-    register_column(header: 'Created At', verbose: true) { |s| s.created_at }
-    register_column(header: 'Created At', verbose: false) do |script|
+    register_column(header: 'Created at', verbose: true) { |s| s.created_at }
+    register_column(header: 'Created at', verbose: false) do |script|
       DateTime.rfc3339(script.created_at).strftime('%d/%m/%y %H:%M')
     end
 

--- a/lib/flight_job/outputs/list_scripts.rb
+++ b/lib/flight_job/outputs/list_scripts.rb
@@ -49,12 +49,7 @@ module FlightJob
       if opts.delete(:json)
         JSONRenderer.new(true, opts[:interactive])
       else
-        super(row_color: :cyan, header_color: :bold, **opts).tap do |output|
-          # NOTE: The rotate flag "hopefully" going to be a new feature to TTY::Table
-          # that stops is rotating in small terminals. OutputMode has no concept of this
-          # feature, currently
-          output.config.merge!(rotate: false) if output.is_a? OutputMode::Outputs::Tabulated
-        end
+        super(row_color: :cyan, header_color: :bold, **opts)
       end
     end
   end

--- a/lib/flight_job/outputs/list_templates.rb
+++ b/lib/flight_job/outputs/list_templates.rb
@@ -39,8 +39,9 @@ module FlightJob
     register_column(header: 'Name') do |template|
       template.id
     end
-    register_column(header: "File (Dir: #{FlightJob.config.templates_dir})", verbose: true) do |template|
-      if $stdout.tty?
+    file_header = "File (Dir: #{FlightJob.config.templates_dir})"
+    register_column(header: file_header, verbose: true) do |template, interactive:|
+      if interactive
         Pathname.new(template.template_path).relative_path_from FlightJob.config.templates_dir
       else
         template.template_path
@@ -51,12 +52,7 @@ module FlightJob
       if opts.delete(:json)
         JSONRenderer.new(true, opts[:interactive])
       else
-        super(row_color: :cyan, header_color: :bold, **opts).tap do |output|
-          # NOTE: The rotate flag "hopefully" going to be a new feature to TTY::Table
-          # that stops is rotating in small terminals. OutputMode has no concept of this
-          # feature, currently
-          output.config.merge!(rotate: false) if output.is_a? OutputMode::Outputs::Tabulated
-        end
+        super(row_color: :cyan, header_color: :bold, **opts)
       end
     end
   end


### PR DESCRIPTION
The time fields have been standardised as `Created at`, `Started at`, `Ended At`.

---

The `StdOut Path` and `StdErr Path` are now combined together as `Output Path` if they are the same in the simplified human readable output.

This proved to be rather tricky as the rendering library (`OuputMode`) assumes that the `headers` are static. This assumption makes it easier to determine the padding of the headers.

In this particular case, the padding issue can be avoided as `StdOut Path` and `OutputPath` are the same length. This allows the internal template to switch out the header with an if-statement. However the padding will break it the lengths are different.