### PR TITLE
Allow scripts to have friendly names

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'tty-markdown'
 gem 'tty-editor'
 gem 'tty-table', github: 'openflighthpc/tty-table', branch: '9b326fcbe04968463da58c000fbb1dd5ce178243'
 gem 'tty-prompt'
-gem 'tty-editor'
 gem 'tty-pager'
 gem 'word_wrap'
 

--- a/etc/flight-job.yaml
+++ b/etc/flight-job.yaml
@@ -86,6 +86,12 @@
 # minimum_terminal_width: 80
 
 # ==============================================================================
+# Maximum ID Length
+# The maximum allowed length for script IDs
+# ==============================================================================
+# max_id_length: 16
+
+# ==============================================================================
 # Maximum Standard Input Size
 # The maximum file size that will be provided to STDIN. The size must be given
 # in Bytes.

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -98,8 +98,7 @@ module FlightJob
       c.summary = 'Display details about a rendered script'
     end
 
-    # XXX: Consider making the method signature: TEMPLATE_NAME [SCRIPT_NAME]
-    create_command 'create-script', 'TEMPLATE_NAME' do |c|
+    create_command 'create-script', 'TEMPLATE_NAME [SCRIPT_ID]' do |c|
       c.summary = 'Render a new script from a template'
       c.slop.string '--answers', <<~MSG.chomp, meta: 'JSON|@filepath|@-'
         Provide the answers as a JSON string.

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -194,8 +194,7 @@ module FlightJob
         file.unlink
       end
 
-      # Checks if the script has and ID error
-      # All other errors are intentionally ignored and must be handled independently
+      # Checks if the script's ID is valid
       def verify_id(id)
         script = Script.new(id: id)
         return if script.valid?(:id_check)

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -77,7 +77,7 @@ module FlightJob
         )
 
         # Apply the identity_name
-        script.identity_name = args[1] if args.length > 1
+        script.id = args[1] if args.length > 1
 
         # Save the script
         script.render_and_save

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -62,6 +62,7 @@ module FlightJob
     attribute :minimum_terminal_width, default: 80
     attribute :check_cron, default: 'libexec/check-cron.sh',
               transform: relative_to(root_path)
+    attribute :max_id_length, default: 16
     attribute :max_stdin_size, default: 1048576
     attribute :log_path, required: false,
               default: '~/.cache/flight/log/share/job.log',
@@ -78,6 +79,7 @@ module FlightJob
     attribute :development, default: false, required: false
   end
 
+  # NOTE: Defined on the top level FlightJob module
   def self.config
     @config ||= Configuration.load
   end

--- a/lib/flight_job/errors.rb
+++ b/lib/flight_job/errors.rb
@@ -48,6 +48,7 @@ module FlightJob
   GeneralError = Error.define_class(2)
   InputError = GeneralError.define_class(3)
   CommandError = GeneralError.define_class(6)
+  DuplicateError = GeneralError.define_class(7)
 
   class InteractiveOnly < InputError
     MSG = 'This command requires an interactive terminal'


### PR DESCRIPTION
The `create script` command has been updated to allow them to have friendly IDs. It is not possible to rename existing scripts as this will break referential integrity between and `jobs` that are started from them.