### PR TITLE
Allow templates to be sorted in a priority oder

### DIFF
--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -48,7 +48,8 @@ module FlightJob
             "required" => ['text', 'value'],
             "properties" => {
               'text' => { "type" => "string" },
-              'value' => { "type" => "string" }
+              'value' => { "type" => "string" },
+              'priority' => { "type" => 'integer' }
             }
           }
         }
@@ -127,6 +128,8 @@ module FlightJob
           FlightJob.logger.debug("Errors: \n") { template.errors.full_messages.join("\n") }
           false
         end
+
+        templates.sort!
 
         templates.each_with_index do |t, idx|
           t.index = idx + 1
@@ -235,6 +238,24 @@ module FlightJob
 
     def to_erb
       ERB.new(File.read(template_path), nil, '-')
+    end
+
+    def priority
+      metadata['priority']
+    end
+
+    protected
+
+    def <=>(other)
+      if self.priority == other.priority
+        self.id <=> other.id
+      elsif self.priority.nil?
+        1
+      elsif other.priority.nil?
+        -1
+      else
+        self.priority <=> other.priority
+      end
     end
   end
 end

--- a/usr/share/mpi-nodes/metadata.yaml
+++ b/usr/share/mpi-nodes/metadata.yaml
@@ -2,7 +2,7 @@ name: Multiple node
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: multinode.sh
-priority: 2000
+priority: 400
 version: 0
 synopsis: Submit a single job that spans multiple nodes where you want exclusive use of each node allocated. 
 description: |

--- a/usr/share/mpi-nodes/metadata.yaml
+++ b/usr/share/mpi-nodes/metadata.yaml
@@ -2,6 +2,7 @@ name: Multiple node
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: multinode.sh
+priority: 2000
 version: 0
 synopsis: Submit a single job that spans multiple nodes where you want exclusive use of each node allocated. 
 description: |

--- a/usr/share/mpi-slots/metadata.yaml
+++ b/usr/share/mpi-slots/metadata.yaml
@@ -2,6 +2,7 @@ name: Multiple slot
 copyright: Copyright (C) 2020 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: mpi-slots.sh
+priority: 2000
 version: 0
 synopsis: Submit a single job that has multiple processes that may span multiple nodes.
 description: |

--- a/usr/share/mpi-slots/metadata.yaml
+++ b/usr/share/mpi-slots/metadata.yaml
@@ -2,7 +2,7 @@ name: Multiple slot
 copyright: Copyright (C) 2020 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: mpi-slots.sh
-priority: 2000
+priority: 300
 version: 0
 synopsis: Submit a single job that has multiple processes that may span multiple nodes.
 description: |

--- a/usr/share/simple-array/metadata.yaml
+++ b/usr/share/simple-array/metadata.yaml
@@ -2,6 +2,7 @@ name: Simple serial array
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: simple-array.sh
+priority: 1000
 version: 0
 synopsis: Submit multiple, similar jobs.
 description: |

--- a/usr/share/simple-array/metadata.yaml
+++ b/usr/share/simple-array/metadata.yaml
@@ -2,7 +2,7 @@ name: Simple serial array
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: simple-array.sh
-priority: 1000
+priority: 200
 version: 0
 synopsis: Submit multiple, similar jobs.
 description: |

--- a/usr/share/simple/metadata.yaml
+++ b/usr/share/simple/metadata.yaml
@@ -2,7 +2,7 @@ name: Simple serial
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: simple.sh
-priority: 1000
+priority: 100
 version: 0
 synopsis: Submit a single job.
 description: |

--- a/usr/share/simple/metadata.yaml
+++ b/usr/share/simple/metadata.yaml
@@ -2,6 +2,7 @@ name: Simple serial
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: simple.sh
+priority: 1000
 version: 0
 synopsis: Submit a single job.
 description: |

--- a/usr/share/smp/metadata.yaml
+++ b/usr/share/smp/metadata.yaml
@@ -2,6 +2,7 @@ name: SMP multiple slot
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: smp.sh
+priority: 2000
 version: 0
 synopsis: Submit a job that has multiple processes where all processes need to reside on a single host.
 description: |

--- a/usr/share/smp/metadata.yaml
+++ b/usr/share/smp/metadata.yaml
@@ -2,7 +2,7 @@ name: SMP multiple slot
 copyright: Copyright (C) 2021 Alces Flight Ltd.
 license: Creative Commons Attribution-ShareAlike 4.0 International
 script_template: smp.sh
-priority: 2000
+priority: 500
 version: 0
 synopsis: Submit a job that has multiple processes where all processes need to reside on a single host.
 description: |


### PR DESCRIPTION
A new optional `priority` field has been added to `templates`. This is used to sort the `templates` into a custom order according to the following rules:

1. `templates` with a `priority` are sorted in ascending order,
2. `templates` with the same `priority` are sorted alphanumerically by their `id`, and
3. `templates` without a `priority` are sorted to the end (obeying condition 2).

---

The default templates have all been assigned either `priority` 1000 or 2000:
* `1000`: `simple` and `simple-array`, and
* `2000`: `mpi-nodes`, `mpi-slots`, and `smp`.

The `(0)-999` and `1001-1999` ranges have been left empty to allow custom templates to be sorted before and between the default blocks, respectively. Technically negative priorities are supported, however there use is discouraged to avoid confusing the end users.

Otherwise the `1000` and `2000` priorities are completely arbitrary. Making them configurable would be tricky as the `priority` needs to be hardcode into the `metadata.yaml` files for the `templates`.

By default, templates without a priority appear at the end of the list. This _feels_ like the appropriate location for these un-prioritised `templates`, however I am open to alternative suggestions on how they can be handled. The `priority` metadata key needs to be optional, as introducing new required keys is a breaking change.