### PR TITLE
Prompt for the name when creating the script

### DIFF
--- a/bin/job
+++ b/bin/job
@@ -52,6 +52,14 @@ begin
   # Builds and runs the CLI
   require_relative '../lib/flight_job/cli'
 
+  # Kill attempt to kill all child processes on exit, this does two things:
+  # * Terminate any remaining scheduler commands as there output will be ignored
+  #   regardless at this point, and
+  # * Terminate any open pagers which would otherwise break the SHELL
+  trap('EXIT') do
+    Process.kill(-Signal.list['TERM'], Process.pid)
+  end
+
   # Runs the command within the original directory
   Dir.chdir(ENV.fetch('FLIGHT_CWD', '.')) do
     OpenFlight.set_standard_env rescue nil

--- a/bin/job
+++ b/bin/job
@@ -52,14 +52,6 @@ begin
   # Builds and runs the CLI
   require_relative '../lib/flight_job/cli'
 
-  # Kill attempt to kill all child processes on exit, this does two things:
-  # * Terminate any remaining scheduler commands as there output will be ignored
-  #   regardless at this point, and
-  # * Terminate any open pagers which would otherwise break the SHELL
-  trap('EXIT') do
-    Process.kill(-Signal.list['TERM'], Process.pid)
-  end
-
   # Runs the command within the original directory
   Dir.chdir(ENV.fetch('FLIGHT_CWD', '.')) do
     OpenFlight.set_standard_env rescue nil
@@ -71,5 +63,4 @@ rescue Interrupt
   else
     $stderr.puts "\nWARNING: Cancelled by user"
   end
-  exit(130)
 end

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -90,10 +90,8 @@ module FlightJob
           reask = true
           while reask
             puts "\n"
-            text = summary
-            # NOTE: There is an off-by-one error somewhere in this logic. It causes the padded
-            #       text to scroll up/down by one line (which shouldn't happen).
-            diff = TTY::Screen.rows - text.lines.count - 1
+            text = summary.chomp
+            diff = TTY::Screen.rows - text.lines.count
             # Work around issues with LESS -SFRX flag
             # The -F/--quit-if-one-screen flag disables less if the summary fits on one page
             # However, the prompt_again question adds an additional X lines, which isn't being
@@ -102,7 +100,7 @@ module FlightJob
             # The 'pager' should still be used, as the user may have changed either PAGER/LESS
             # env vars. Instead the text is padded with newlines, if its length is X lines less
             # than the terminal height
-            if 0 < diff && diff < 6
+            if 0 < diff && diff < 7
               text = "#{text}#{"\n" * diff}"
             end
             pager.page text

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -50,7 +50,13 @@ module FlightJob
         <% end -%>
 
         <%= pastel.bold 'Notes:' %>
-        <%= (notes.to_s.empty? ? pastel.yellow('(none)') : pastel.green(notes)) %>
+        <% if notes.empty? -%>
+        <%= pastel.yellow('(none)') %>
+        <% else -%>
+        <% notes.each_line do |line| # Colourise each line so it appears correctly in the pager -%>
+        <%= pastel.green(line.chomp) %>
+        <% end -%>
+        <% end -%>
       TEMPLATE
 
       # NOTE: The questions must be topologically sorted on their dependencies otherwise

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -42,7 +42,16 @@ module FlightJob
         <%
             questions.each do |question|
               next unless prompt?(question) -%>
-        <%=   pastel.blue.bold(question.text) -%>
+        <%
+              if /[[:alnum:]]/.match?(question.text[-1])
+                text = question.text
+                delim = ':'
+              else
+                text = question.text[0..-2]
+                delim = question.text[-1]
+              end
+        -%>
+        <%=   pastel.blue.bold(text) -%><%= pastel.bold(delim) -%>
         <%    value = answers[question.id]
               value = question.default if value.nil?
               value = (value.is_a?(Array) ? value.join(',') : value.to_s)

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -206,7 +206,7 @@ module FlightJob
             show_help: :always }
           choices = {
             'Change the script identifier.' => :name,
-            "#{notes.empty? ? 'Define' : 'Change'} the notes about the script." => :notes,
+            "#{notes.empty? ? 'Add' : 'Edit the'} notes about the script." => :notes,
             'Change the answers to selected questions.' => :selected,
             'Re-ask all the questions.' => :all,
             'Save and quit!' => :finish

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -349,7 +349,6 @@ module FlightJob
           prompter = QuestionPrompter.new(pastel, pager, template.generation_questions, notes || '', name)
           prompter.prompt_invalid_name
           prompter.prompt_all if answers.nil?
-          prompter.prompt_notes if notes.nil?
           prompter.prompt_loop
 
         # Populate missing answers/notes in a non-interactive shell

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -88,6 +88,7 @@ module FlightJob
           }
           case prompt.select("Would you like to change the script name or answers?", choices, **opts)
           when :all
+            prompt_name
             prompt_all
             prompt_notes
             true
@@ -121,9 +122,9 @@ module FlightJob
 
         def prompt_notes(confirm = true)
           if confirm
-            open = prompt.yes?("Define notes about the script?", default: true)
+            open = prompt.yes?("#{notes? ? 'Update' : 'Define'} notes about the script?", default: !notes?)
           else
-            prompt.keypress('Define notes about the script. Press any key to continue...')
+            prompt.keypress("#{notes? ? 'Updating' : 'Defining'} notes about the script. Press any key to continue...")
             open = true
           end
           if open
@@ -159,6 +160,11 @@ module FlightJob
         end
 
         private
+
+        # Checks if the notes have been defined
+        def notes?
+          !notes.to_s.empty?
+        end
 
         def prompt
           @prompt ||= TTY::Prompt.new(help_color: :yellow)
@@ -282,7 +288,7 @@ module FlightJob
           reask = true
           prompter = QuestionPrompter.new(pastel, template.generation_questions, notes || '')
           prompter.prompt_all if answers.nil?
-          notes = prompter.prompt_notes if notes.nil?
+          notes = prompter.prompt_notes
           while reask
             puts "\n\n"
             pager.page prompter.summary

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -82,11 +82,19 @@ module FlightJob
         # Prompts the user for any answers they wish to change
         # return [Boolean] if the user requested questions to be re-asked
         def prompt_again
-          opts = { default: name ? 4 : 3, show_help: :always }
+          opts = {
+            default: if name.nil?
+                       3
+                     elsif notes?
+                       5
+                     else
+                       4
+                     end,
+            show_help: :always }
           choices = {
-            'All' => :all, 'Selected' => :selected, 'Name Only' => :name, 'Finish' => :finish
+            'All' => :all, 'Selected' => :selected, 'Name Only' => :name, 'Notes Only' => :notes, 'Finish' => :finish
           }
-          case prompt.select("Would you like to change the script name or answers?", choices, **opts)
+          case prompt.select("Would you like to change the script name, answers, or notes?", choices, **opts)
           when :all
             prompt_name
             prompt_all
@@ -115,6 +123,8 @@ module FlightJob
           when :name
             prompt_name
             true
+          when :notes
+            prompt_notes(false)
           else
             false
           end

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -90,7 +90,7 @@ module FlightJob
           reask = true
           while reask
             puts "\n"
-            text = summary.chomp
+            text = summary.sub(/\n+\Z/, '')
             diff = TTY::Screen.rows - text.lines.count
             # Work around issues with LESS -SFRX flag
             # The -F/--quit-if-one-screen flag disables less if the summary fits on one page
@@ -339,8 +339,8 @@ module FlightJob
         answers = answers_input
         notes = notes_input
 
-        # Skip this section if both have been provided
-        if answers && notes
+        # Skip this section if all the fields have been provided
+        if answers && notes && name
           # NOOP
 
         # Handle STDIN contention (disables the prompts)
@@ -351,12 +351,12 @@ module FlightJob
           ERROR
           notes ||= ''
 
-        # Prompt for this missing answers/notes
+        # Prompt for this missing answers/notes/name
         elsif $stdout.tty?
           prompter = QuestionPrompter.new(pastel, pager, template.generation_questions, notes || '', name)
           prompter.prompt_invalid_name
           prompter.prompt_all if answers.nil?
-          prompter.prompt_notes
+          prompter.prompt_notes if notes.nil?
           prompter.prompt_loop
 
         # Populate missing answers/notes in a non-interactive shell

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -39,24 +39,33 @@ module FlightJob
         <%= pastel.bold 'Name: ' -%><%= (name ? pastel.green(name) : pastel.yellow('(To Be Determined)')) %>
 
         <%= pastel.bold 'Answers:' %>
-        <% questions.each do |question| -%>
-        <% next unless asked[question.id] -%>
-        <%= pastel.bold.cyan(question.text) %>
         <%
-          value = answers[question.id]
-          value = (value.is_a?(Array) ? value.join(',') : value.to_s)
+            questions.each do |question|
+              next unless asked[question.id] -%>
+        <%=   pastel.blue.bold(question.text) -%>
+        <%    value = answers[question.id]
+              value = (value.is_a?(Array) ? value.join(',') : value.to_s)
+              if value.empty?
         -%>
-        <%= (value.empty? ? pastel.yellow('(none)') : pastel.green(value)) %>
-        <% end -%>
+        <%=     " #{pastel.yellow('(none)')}" %>
+        <%    elsif question.format['type'] == 'multiline_text' -%>
+
+        <%      value.each_line do |line| -%>
+        <%=       pastel.green(line.chomp) %>
+        <%      end -%>
+        <%    else -%>
+        <%=     " #{pastel.green(value)}" %>
+        <%    end -%>
+        <%  end -%>
 
         <%= pastel.bold 'Notes:' %>
-        <% if notes.empty? -%>
-        <%= pastel.yellow('(none)') %>
-        <% else -%>
-        <% notes.each_line do |line| # Colourise each line so it appears correctly in the pager -%>
-        <%= pastel.green(line.chomp) %>
-        <% end -%>
-        <% end -%>
+        <%  if notes.empty? -%>
+        <%=   pastel.yellow('(none)') %>
+        <%  else -%>
+        <%    notes.each_line do |line| -%>
+        <%=     pastel.green(line.chomp) %>
+        <%    end -%>
+        <%  end -%>
       TEMPLATE
 
       # NOTE: The questions must be topologically sorted on their dependencies otherwise

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -41,7 +41,7 @@ module FlightJob
         <%= pastel.bold 'Answers:' %>
         <%
             questions.each do |question|
-              next unless asked[question.id] -%>
+              next unless prompt?(question) -%>
         <%=   pastel.blue.bold(question.text) -%>
         <%    value = answers[question.id]
               value = (value.is_a?(Array) ? value.join(',') : value.to_s)
@@ -207,7 +207,7 @@ module FlightJob
             selected = prompt.multi_select("Which questions would you like to change?", **opts) do |menu|
               menu.choice "#{name ? 'Update' : 'Set'} the script name?", :name
               questions.each do |question|
-                next unless asked[question.id]
+                next unless prompt?(question)
                 menu.choice question.text, question
               end
               menu.choice 'Update notes about the script?', :notes
@@ -275,7 +275,6 @@ module FlightJob
         end
 
         def prompt_question(question)
-          asked[question.id] = true # Flags the question as asked
           answers[question.id] = case question.format['type']
           when 'text'
             prompt.ask(question.text, default: answers[question.id])
@@ -301,11 +300,6 @@ module FlightJob
           else
             raise InternalError, "Unexpectedly reached question type: #{question.format['type']}"
           end
-        end
-
-        # Tracks if a question has been asked
-        def asked
-          @asked ||= {}
         end
 
         # Checks if any of the questions have dependencies


### PR DESCRIPTION
The `id`/"name" of the script is now prompted for in an interactive session.

The `name` prompt is displayed after the summary as it may depend on the given answers/notes. It has been integrated into the `prompt_again` mechanism so it can be change.

In addition, various tweaks have been made to the format of the `summary` and the defaults to the prompts. This should hopefully improve the work flow.