### PR TITLE
Map the slurm states to flight-job states

### DIFF
--- a/etc/flight-job.yaml
+++ b/etc/flight-job.yaml
@@ -66,6 +66,18 @@
 # monitor_script_path: libexec/slurm/monitor.sh
 
 # ==============================================================================
+# State Map Path
+# Specify the path to the state map file. This file should contain a list of
+# "scheduler states" and the corresponding "flight job state".
+#
+# Relative paths are expanded from the install directory.
+#
+# WARNING: Unrecognized flight-job states may prevent the job from being updated.
+# Ensure all flight-job states are valid (see: lib/flight_job/models/script.rb)
+# ==============================================================================
+# monitor_script_path: libexec/slurm/monitor.sh
+
+# ==============================================================================
 # Check Cron Path
 # Specify the path to the script which checks if cron is setup to run the
 # monitor.

--- a/etc/flight-job.yaml
+++ b/etc/flight-job.yaml
@@ -75,7 +75,7 @@
 # WARNING: Unrecognized flight-job states may prevent the job from being updated.
 # Ensure all flight-job states are valid (see: lib/flight_job/models/script.rb)
 # ==============================================================================
-# monitor_script_path: libexec/slurm/monitor.sh
+# state_map_path: etc/state-maps/slurm.yaml
 
 # ==============================================================================
 # Check Cron Path

--- a/etc/state-maps/slurm.yaml
+++ b/etc/state-maps/slurm.yaml
@@ -1,0 +1,86 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+#-------------------------------------------------------------------------------
+# WARNING - README
+#
+# This is an internally managed file, any changes maybe lost on the next update!
+# Changes should be made by duplicating this file and reconfiguring your
+# installation of flight-job
+#
+# This file is not validated! It must return the mapping of scheduler to
+# flight-job states. Incorrect maps may lead to undefined behaviour.
+#-------------------------------------------------------------------------------
+
+BF:             FAILED
+BOOT_FAIL:      FAILED
+CA:             CANCELLED
+CANCELLED:      CANCELLED
+CD:             COMPLETED
+COMPLETED:      COMPLETED
+CF:             RUNNING
+CONFIGURING:    RUNNING
+CG:             RUNNING
+COMPLETING:     RUNNING
+DL:             FAILED
+DEADLINE:       FAILED
+F:              FAILED
+FAILED:         FAILED
+NF:             FAILED
+NODE_FAIL:      FAILED
+OOM:            FAILED
+OUT_OF_MEMORY:  FAILED
+PD:             PENDING
+PENDING:        PENDING
+PR:             FAILED
+PREEMPTED:      FAILED
+R:              RUNNING
+RUNNING:        RUNNING
+RD:             PENDING # TBC
+RESV_DEL_HOLD:  PENDING # as above
+RF:             PENDING
+REQUEUE_FED:    PENDING
+RH:             PENDING # TBC
+REQUEUE_HOLD:   PENDING # as above
+RQ:             PENDING
+REQUEUED:       PENDING
+RS:             RUNNING # TBC
+RESIZING:       RUNNING # as above
+RV:             FAILED # Currently jobs can not be tracked if they change cluster
+REVOKED:        FAILED # as above
+SI:             RUNNING
+SIGNALING:      RUNNING
+SE:             UNKNOWN # The job is in a custom state, and thus unknown
+SPECIAL_EXIT:   UNKNOWN # as above
+SO:             RUNNING
+STAGE_OUT:      RUNNING
+ST:             RUNNING # This is a bit of a misnomer, consider defining a new state
+STOPPED:        RUNNING # as above
+S:              RUNNING # as above
+SUSPENDED:      RUNNING # as above
+TO:             FAILED
+TIMEOUT:        FAILED

--- a/etc/state-maps/slurm.yaml
+++ b/etc/state-maps/slurm.yaml
@@ -60,22 +60,22 @@ PR:             FAILED
 PREEMPTED:      FAILED
 R:              RUNNING
 RUNNING:        RUNNING
-RD:             PENDING # TBC
-RESV_DEL_HOLD:  PENDING # as above
+RD:             PENDING
+RESV_DEL_HOLD:  PENDING
 RF:             PENDING
 REQUEUE_FED:    PENDING
-RH:             PENDING # TBC
-REQUEUE_HOLD:   PENDING # as above
+RH:             PENDING
+REQUEUE_HOLD:   PENDING
 RQ:             PENDING
 REQUEUED:       PENDING
-RS:             RUNNING # TBC
-RESIZING:       RUNNING # as above
+RS:             RUNNING
+RESIZING:       RUNNING
 RV:             FAILED # Currently jobs can not be tracked if they change cluster
 REVOKED:        FAILED # as above
 SI:             RUNNING
 SIGNALING:      RUNNING
-SE:             UNKNOWN # The job is in a custom state, and thus unknown
-SPECIAL_EXIT:   UNKNOWN # as above
+SE:             PENDING
+SPECIAL_EXIT:   PENDING
 SO:             RUNNING
 STAGE_OUT:      RUNNING
 ST:             RUNNING # This is a bit of a misnomer, consider defining a new state

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -54,6 +54,8 @@ module FlightJob
               transform: relative_to(root_path)
     attribute :jobs_dir, default: '~/.local/share/flight/job/jobs',
               transform: relative_to(root_path)
+    attribute :state_map_path, default: 'etc/state-maps/slurm.yaml',
+              transform: relative_to(root_path)
     attribute :submit_script_path, default: 'libexec/slurm/submit.sh',
               transform: relative_to(root_path)
     attribute :monitor_script_path, default: 'libexec/slurm/monitor.sh',

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -349,7 +349,7 @@ module FlightJob
           # the RUNNING_STATES.
           #
           # Consider refactoring
-          if ['', nil].include? data['start_time'] || !RUNNING_OR_TERMINAL_STATES.include?(state)
+          if ['', nil].include?(data['start_time']) || !RUNNING_OR_TERMINAL_STATES.include?(state)
             self.start_time = nil
           else
             begin

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -50,6 +50,7 @@ module FlightJob
         "script_id" => { "type" => "string" },
         "created_at" => { "type" => "string", "format" => "date-time" },
         "state" => { "type" => "string", "enum" => STATES },
+        "scheduler_state" => { "type" => "string" },
         # NOTE: In practice this will normally be an integer, however this is not
         # guaranteed. As such it must be stored as a string.
         "scheduler_id" => { "type" => ["string", "null"] },
@@ -255,8 +256,9 @@ module FlightJob
     end
 
     [
-      "submit_status", "submit_stdout", "submit_stderr", "script_id", "state", "scheduler_id",
-      "stdout_path", "stderr_path", "reason", "start_time", "end_time"
+      "submit_status", "submit_stdout", "submit_stderr", "script_id", "state",
+      "scheduler_id", "scheduler_state", "stdout_path", "stderr_path", "reason",
+      "start_time", "end_time"
     ].each do |method|
       define_method(method) { metadata[method] }
       define_method("#{method}=") { |value| metadata[method] = value }
@@ -266,10 +268,13 @@ module FlightJob
       { "id" => id }.merge(metadata)
     end
 
-    # Takes the scheduler's state and converts it to an internal flight-job one
-    # NOTE: The `state=` method should be used when updating the internal state directly
+    # Takes the scheduler's state and converts it to an internal flight-job
+    # one.
+    # NOTE: The `state=` method should be used when updating the internal
+    # state directly
     def update_scheduler_state(scheduler_state)
       self.state = STATE_MAP.fetch(scheduler_state, 'UNKNOWN')
+      self.scheduler_state = scheduler_state
     end
 
     def submit

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -33,6 +33,7 @@ require 'open3'
 
 module FlightJob
   class Job < ApplicationModel
+    STATE_MAP = YAML.load(File.read(FlightJob.config.state_map_path))
     TERMINAL_STATES = ['FAILED', 'COMPLETED', 'CANCELLED', 'UNKNOWN']
     RUNNING_STATES = ['RUNNING']
     RUNNING_OR_TERMINAL_STATES = [*RUNNING_STATES, *TERMINAL_STATES]
@@ -268,11 +269,7 @@ module FlightJob
     # Takes the scheduler's state and converts it to an internal flight-job one
     # NOTE: The `state=` method should be used when updating the internal state directly
     def update_scheduler_state(scheduler_state)
-      if STATES.include? scheduler_state
-        self.state = scheduler_state
-      else
-        'UNKNOWN'
-      end
+      self.state = STATE_MAP.fetch(scheduler_state, 'UNKNOWN')
     end
 
     def submit


### PR DESCRIPTION
A mapping file of all slurm states has been added. It allows `scontrol` to return any state and map it to a known `flight-job` internal state. This prevents the proliferation of states for the time being, however some states (such as `TIMEOUT`) might need to be incorporated into `flight-job` proper.

A new concept of `RUNNING_STATES` has been added. These indicate the job has actually started and the `start_time` should be saved.