### PR TITLE
Fix start_time for cancelled jobs and sort scripts/jobs

### DIFF
--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -106,7 +106,7 @@ module FlightJob
           FlightJob.logger.debug(job.errors)
           nil
         end
-      end.reject(&:nil?)
+      end.reject(&:nil?).sort
     end
 
     def self.load_active
@@ -396,6 +396,16 @@ module FlightJob
       end
     end
 
+    protected
+
+    def <=>(other)
+      if created_at.nil? || other.created_at.nil?
+        0 # This case SHOULD NOT be reached in practice, so further sorting isn't required
+      else
+        Time.parse(created_at) <=> Time.parse(other.created_at)
+      end
+    end
+
     private
 
     def process_output(type, status, out)
@@ -439,6 +449,7 @@ module FlightJob
       cmd_stdout, cmd_stderr, status = Open3.capture3(env, *cmd, unsetenv_others: true, close_others: true)
 
       FlightJob.logger.debug <<~DEBUG
+        COMMAND: #{cmd.join(" ")}
         STATUS: #{status.exitstatus}
         STDOUT:
         #{cmd_stdout}

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -56,7 +56,7 @@ module FlightJob
           FlightJob.logger.debug(script.errors)
           nil
         end
-      end.reject(&:nil?)
+      end.reject(&:nil?).sort
     end
 
     attr_reader :id
@@ -290,6 +290,16 @@ module FlightJob
 
     def raise_duplicate_id_error
       raise DuplicateError, "The ID already exists!"
+    end
+
+    protected
+
+    def <=>(other)
+      if id.nil? || id.nil?
+        0 # This case SHOULD NOT be reached in practice, so further sorting isn't required
+      else
+        id <=> other.id
+      end
     end
 
     private

--- a/libexec/check-cron.sh
+++ b/libexec/check-cron.sh
@@ -26,6 +26,14 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 
+#-------------------------------------------------------------------------------
+# WARNING - README
+#
+# This is an internally managed file, any changes maybe lost on the next update!
+# Please make any installation specific changes by duplicating this file and
+# reconfiguring the application.
+#-------------------------------------------------------------------------------
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 BIN="$DIR/run-monitor.sh"
 

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -52,7 +52,7 @@ TEMPLATE
 raw_control=$(scontrol show job "$1" --oneline 2>&1)
 exit_status="$?"
 control=$(echo "$raw_control" | head -n 1 | tr ' ' '\n')
-cat <<EOF
+cat <<EOF >&2
 scontrol:
 $control
 EOF
@@ -78,7 +78,7 @@ elif [[ "$raw_control" == "slurm_load_jobs error: Invalid job id specified" ]]; 
   raw_acct=$(sacct --noheader --parsable --jobs "$1" --format State,Reason,START,END,AllocTRES)
   exit_status="$?"
   acct=$(echo "$raw_acct" | head -n1)
-  cat <<EOF
+  cat <<EOF >&2
 
 sacct:
 $raw_acct

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -96,7 +96,7 @@ elif [[ "$exit_status" -eq 0 ]]; then
   # sacct sometimes tacks info onto the end of the state
   state=$(echo "$acct" | cut -d'|' -f1 | cut -d' ' -f1)
   reason=$(echo "$acct" | cut -d'|' -f2)
-  if [ "$(echo "$acct" | cut -d'|' -f5)" ]; then
+  if [ -n "$(echo "$acct" | cut -d'|' -f5)" ]; then
     # Set the start_time if any trackable resources where allocated to the job
     start_time=$(echo "$acct" | cut -d'|' -f3)
   else

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -54,7 +54,7 @@ exit_status="$?"
 control=$(echo "$raw_control" | head -n 1 | tr ' ' '\n')
 cat <<EOF
 scontrol:
-$raw_control
+$control
 EOF
 
 if [[ "$exit_status" -eq 0 ]]; then
@@ -64,7 +64,7 @@ if [[ "$exit_status" -eq 0 ]]; then
     reason=""
   fi
 
-  if [[ "$(echo "$control" | grep "^NodeList=" | cut -d= -f2)" -eq "(null)" ]]; then
+  if [[ "$(echo "$control" | grep "^NodeList=" | cut -d= -f2)" == "(null)" ]]; then
     # Skip setting the start_time when there is no allocation
     start_time=""
   else

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -92,17 +92,18 @@ EOF
     reason=''
 
   # Extract the output from sacct
-  elif [[ "$exit_status" -eq 0 ]]; then
-    state=$(echo "$acct" | cut -d'|' -f1)
-    reason=$(echo "$acct" | cut -d'|' -f2)
-    if [ "$(echo "$sacct" | cut -d'|' -f5)" ]; then
-      # Set the start_time if any trackable resources where allocated to the job
-      start_time=$(echo "$acct" | cut -d'|' -f3)
-    else
-      # Skip setting the start_time when there are no allocated TRESS
-      start_time=""
-    fi
-    end_time=$(echo "$acct" | cut -d'|' -f4)
+elif [[ "$exit_status" -eq 0 ]]; then
+  # sacct sometimes tacks info onto the end of the state
+  state=$(echo "$acct" | cut -d'|' -f1 | cut -d' ' -f1)
+  reason=$(echo "$acct" | cut -d'|' -f2)
+  if [ "$(echo "$acct" | cut -d'|' -f5)" ]; then
+    # Set the start_time if any trackable resources where allocated to the job
+    start_time=$(echo "$acct" | cut -d'|' -f3)
+  else
+    # Skip setting the start_time when there are no allocated TRESS
+    start_time=""
+  fi
+  end_time=$(echo "$acct" | cut -d'|' -f4)
 
   # Exit the monitor process if sacct fails to prevent the job being updated
   else


### PR DESCRIPTION
The list outputs are now sorted according to:

* `scripts`: By the `id`/`name` as this can be set by the end user, and
* `jobs`: By the `created_at` time

---

The `start_time` time is no longer set for jobs which are cancelled whilst in a pending state. This is handled by the `slurm/monitor.sh` script to prevent issues with polling intervals.

Jobs which were not allocated resources are "assumed" not to have started. This condition is detected in two ways:
* With `scontrol` when the `NodeList` is empty (technically `(null)`), and
* When `AllocTRES` field is empty in `sacct`.