### PR TITLE
Allow a script's content to be updated non-interactively

### DIFF
--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -121,6 +121,15 @@ module FlightJob
         Changes you make will affect any future jobs submitted from this script,
         but will not affect jobs already submitted.
       DESC
+      c.slop.string '--content', <<~MSG.chomp, meta: '@filepath|@-'
+        Provide the content without the use of the editor. The provided file will
+        replace the existing version
+
+        Files are specified as @filepath or STDIN as @-.
+      MSG
+      c.slop.boolean '--force', <<~MSG.chomp
+        Skip the confirmation when using the --content flag
+      MSG
     end
 
     create_command 'edit-script-notes', 'SCRIPT_ID' do |c|


### PR DESCRIPTION
A new `--content` flag has been added to the `edit-script` command. This allows the script to be updated without using the `editor`.

The `--content` flag is broadly the same as the `--notes` flag in `edit-script-notes`. The main difference is `--content` must specified as a filepath. Bare words inputs are not supported as it is not feasible to provide the entire script this way.

---

This has the following goals:

1. Makes it easier for the 'api' to update the script without polling for the file path,
2. Maintains consistence between the `notes` and `script` commands/management, and
3. Allows for following work flow without the user going through the internal data directory.

```
# Create a backup
$ flight job view-script foobar > /tmp/foobar.bkup

# Try experimental changes
$ flight job edit-script foobar
$ flight job submit foobar

# Revert to backup without having to go through the internal directory
$ flight job edit-script foobar --content @/tmp/foobar.bkup --force
```