### PR TITLE
Correctly terminate the process after interrupt

### DIFF
--- a/bin/job
+++ b/bin/job
@@ -63,4 +63,5 @@ rescue Interrupt
   else
     $stderr.puts "\nWARNING: Cancelled by user"
   end
+  raise SignalException.new(2)
 end

--- a/bin/job
+++ b/bin/job
@@ -59,9 +59,9 @@ begin
   end
 rescue Interrupt
   if Kernel.const_defined?(:Paint)
-    $stderr.puts "\n#{Paint['WARNING', :underline, :yellow]}: Cancelled by user"
+    $stderr.print "\n#{Paint['WARNING', :underline, :yellow]}: Cancelled by user"
   else
-    $stderr.puts "\nWARNING: Cancelled by user"
+    $stderr.print "\nWARNING: Cancelled by user"
   end
   raise SignalException.new(2)
 end


### PR DESCRIPTION
This stops the pager from breaking the terminal