### PR TITLE
Save the estimated start and end times

### DIFF
--- a/etc/job.development.yaml
+++ b/etc/job.development.yaml
@@ -26,3 +26,5 @@
 #==============================================================================
 log_path: null
 log_level: debug
+jobs_dir: var/jobs
+scripts_dir: var/scripts

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -215,6 +215,8 @@ module FlightJob
     alias_command 'cp',     'copy-template'
     alias_command 'copy',   'copy-template'
     alias_command 'ls-job-results', 'list-job-results'
+    alias_command 'list',   'list-jobs'
+    alias_command 'info',   'info-job'
 
     if Flight.env.development?
       create_command 'console' do |c|

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -34,10 +34,10 @@ require 'open3'
 module FlightJob
   class Job < ApplicationModel
     STATE_MAP = YAML.load(File.read(FlightJob.config.state_map_path))
+    PENDING_STATES = ['PENDING']
     TERMINAL_STATES = ['FAILED', 'COMPLETED', 'CANCELLED', 'UNKNOWN']
     RUNNING_STATES = ['RUNNING']
-    RUNNING_OR_TERMINAL_STATES = [*RUNNING_STATES, *TERMINAL_STATES]
-    STATES = ['PENDING', *RUNNING_STATES, *TERMINAL_STATES]
+    STATES = [*PENDING_STATES, *RUNNING_STATES, *TERMINAL_STATES]
 
     SCHEMA = JSONSchemer.schema({
       "type" => "object",
@@ -59,7 +59,9 @@ module FlightJob
         "results_dir" => { "type" => ["string", "null"] },
         "reason" => { "type" => ["string", "null"] },
         "start_time" => { "type" => ["string", "null"], "format" => "date-time" },
-        "end_time" => { "type" => ["string", "null"], "format" => "date-time" }
+        "end_time" => { "type" => ["string", "null"], "format" => "date-time" },
+        "estimated_start_time" => { "type" => ["string", "null"], "format" => "date-time" },
+        "estimated_end_time" => { "type" => ["string", "null"], "format" => "date-time" }
       }
     })
 
@@ -93,7 +95,9 @@ module FlightJob
         "state" => { "type" => "string" },
         "reason" => { "type" => ["string", "null"] },
         "start_time" => { "type" => ["string", "null"] },
-        "end_time" => { "type" => ["string", "null"] }
+        "end_time" => { "type" => ["string", "null"] },
+        "estimated_start_time" => { "type" => ["string", "null"] },
+        "estimated_end_time" => { "type" => ["string", "null"] }
       }
     })
 
@@ -260,7 +264,7 @@ module FlightJob
     [
       "submit_status", "submit_stdout", "submit_stderr", "script_id", "state",
       "scheduler_id", "scheduler_state", "stdout_path", "stderr_path", "reason",
-      "start_time", "end_time", "results_dir"
+      "start_time", "end_time", "estimated_start_time", "estimated_end_time", "results_dir"
     ].each do |method|
       define_method(method) { metadata[method] }
       define_method("#{method}=") { |value| metadata[method] = value }
@@ -343,43 +347,10 @@ module FlightJob
         process_output('monitor', status, stdout) do |data|
           update_scheduler_state(data['state'])
 
-          # The slurm monitor script will report the "expected start/end times"
-          # as if they where the actual times. This means "start_time" should
-          # only be updated when in a running or terminal state. Similarly, the
-          # "end_time" should only be updated when in a terminal state.
-          #
-          # NOTE: This *might* give erroneous results if the job transitioned
-          # from pending to terminal. In these cases, they would not have technically
-          # started, but slurm may still set the "start_time"
-          #
-          # It is not possible to detect this condition at this point, as the monitor
-          # runs infrequently. Thus a fast running job may "appear" to have skipped
-          # the RUNNING_STATES.
-          #
-          # Consider refactoring
-          if ['', nil].include?(data['start_time']) || !RUNNING_OR_TERMINAL_STATES.include?(state)
-            self.start_time = nil
-          else
-            begin
-              self.start_time = Time.parse(data['start_time']).to_datetime.rfc3339
-            rescue ArgumentError
-              FlightJob.logger.error "Failed to parse start_time: #{data['start_time']}"
-              FlightJob.logger.debug $!.full_message
-              raise_command_error
-            end
-          end
-
-          if ['', nil].include?(data['end_time']) || !TERMINAL_STATES.include?(state)
-            self.end_time = nil
-          else
-            begin
-              self.end_time = Time.parse(data['end_time']).to_datetime.rfc3339
-            rescue ArgumentError
-              FlightJob.logger.error "Failed to parse end_time: #{data['end_time']}"
-              FlightJob.logger.debug $!.full_message
-              raise_command_error
-            end
-          end
+          process_times data['estimated_start_time'],
+                        data['start_time'],
+                        data['estimated_end_time'],
+                        data['end_time']
 
           if data['reason'] == ''
             self.reason = nil
@@ -410,6 +381,56 @@ module FlightJob
     end
 
     private
+
+    def process_times(est_start, start, est_end, end_time)
+      # The monitor script does not always distinguish between actual/estimated
+      # start/end times. Doing so reliable would require knowledge of the state
+      # mapping file as 'scontrol' does not make a distinction.
+      #
+      # Instead the start_time/end_time/estimated_start_time/estimated_end_time
+      # *may* always be reported back from the monitor.sh script. Instead the
+      # following rules are used to set the times:
+      # * 'estimated_start_time': Is (un)set on pending states,
+      # * 'start_time': Is set on running or terminal states,
+      # * 'estimated_end_time': Is (un)set on pending and running states, and
+      # * 'end_time': Is set on terminal states.
+      #
+      # The estimated times will always be set (or unset) on there corresponding
+      # states. This provides additional control over them, as they may change.
+      # The actual times are considered static and can not be unset, however they
+      # maybe updated.
+
+      # (Un)set the estimated_start_time
+      if PENDING_STATES.include?(state)
+        self.estimated_start_time = parse_time(est_start, type: 'estimated_start_time')
+      end
+
+      # Set the start_time
+      if [*RUNNING_STATES, *TERMINAL_STATES].include?(state)
+        parsed = parse_time(start, type: 'start_time')
+        self.start_time = parsed if parsed
+      end
+
+      # (Un)set the estimated_end_time
+      if [*PENDING_STATES, *RUNNING_STATES].include?(state)
+        self.estimated_end_time = parse_time(est_end, type: 'estimated_end_time')
+      end
+
+      # Set the end_time
+      if TERMINAL_STATES.include?(state)
+        parsed = parse_time(end_time, type: 'end_time')
+        self.end_time = parsed if parsed
+      end
+    end
+
+    def parse_time(time, type:)
+      return nil if ['', nil].include?(time)
+      Time.parse(time).strftime("%Y-%m-%dT%T%:z")
+    rescue ArgumentError
+      FlightJob.logger.error "Failed to parse #{type}: #{time}"
+      FlightJob.logger.debug $!.full_message
+      raise_command_error
+    end
 
     def process_output(type, status, out)
       schema = case type

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -270,6 +270,46 @@ module FlightJob
       define_method("#{method}=") { |value| metadata[method] = value }
     end
 
+    def format_start_time(verbose)
+      if start_time.nil?
+        nil
+      elsif verbose
+        start_time
+      else
+        DateTime.rfc3339(start_time).strftime('%d/%m/%y %H:%M')
+      end
+    end
+
+    def format_end_time(verbose)
+      if end_time.nil?
+        nil
+      elsif verbose
+        end_time
+      else
+        DateTime.rfc3339(end_time).strftime('%d/%m/%y %H:%M')
+      end
+    end
+
+    def format_estimated_start_time(verbose)
+      if estimated_start_time.nil?
+        nil
+      elsif verbose
+        estimated_start_time
+      else
+        DateTime.rfc3339(estimated_start_time).strftime('%d/%m/%y %H:%M')
+      end
+    end
+
+    def format_estimated_end_time(verbose)
+      if estimated_end_time.nil?
+        nil
+      elsif verbose
+        estimated_end_time
+      else
+        DateTime.rfc3339(estimated_end_time).strftime('%d/%m/%y %H:%M')
+      end
+    end
+
     def serializable_hash
       { "id" => id }.merge(metadata)
     end

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -117,10 +117,10 @@ module FlightJob
     #
     # Consider reordering on the next major version bump.
     register_attribute(header: 'Results Dir') { |j| j.results_dir }
-    register_attribute(verbose: true, header: 'Estimated Start') do |job|
+    register_attribute(verbose: true, header: 'Estimated start') do |job|
       job.format_estimated_start_time(true)
     end
-    register_attribute(verbose: true, header: 'Estimated Finish') do |job|
+    register_attribute(verbose: true, header: 'Estimated end') do |job|
       job.format_estimated_end_time(true)
     end
 

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -34,7 +34,7 @@ module FlightJob
     TEMPLATE = <<~ERB
       <%
         verbose = output.context[:verbose]
-        main = output.callables.config_select(:section, :main)
+        main = output.callables.config_select(:section, :other)
         paths = main.select(&:paths?)
 
         # Determine if the STDOUT/STDERR paths should be combined or
@@ -66,17 +66,17 @@ module FlightJob
       <% end -%>
     ERB
 
-    register_attribute(section: :main, header: 'ID') { |j| j.id }
-    register_attribute(section: :main, header: 'Script ID') { |j| j.script_id }
-    register_attribute(section: :main, header: 'Scheduler ID') { |j| j.scheduler_id }
-    register_attribute(section: :main, header: 'State') { |j| j.state }
+    register_attribute(header: 'ID') { |j| j.id }
+    register_attribute(header: 'Script ID') { |j| j.script_id }
+    register_attribute(header: 'Scheduler ID') { |j| j.scheduler_id }
+    register_attribute(header: 'State') { |j| j.state }
 
     # Show a boolean in the "simplified" output, and the exit code in the verbose
-    register_attribute(section: :main, header: 'Submitted', verbose: false) { |j| j.submit_status == 0 }
+    register_attribute(header: 'Submitted', verbose: false) { |j| j.submit_status == 0 }
     # NOTE: There is a rendering issue of integers into the TSV output. Needs investigation
-    register_attribute(section: :main, header: 'Submit Status', verbose: true) { |j| j.submit_status.to_s }
+    register_attribute(header: 'Submit Status', verbose: true) { |j| j.submit_status.to_s }
 
-    register_attribute(section: :main, header: 'Submitted at') do |job, verbose:|
+    register_attribute(header: 'Submitted at') do |job, verbose:|
       if verbose
         job.created_at
       else
@@ -84,25 +84,11 @@ module FlightJob
       end
     end
 
-    # NOTE: These could be the predicted times instead of the actual, consider
-    # delineating the two
-    register_attribute(section: :main, header: 'Started at') do |job, verbose:|
-      if job.start_time.nil?
-        nil
-      elsif verbose
-        job.start_time
-      else
-        DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
-      end
+    register_attribute(header: 'Started at') do |job, verbose:|
+      job.format_start_time(verbose)
     end
-    register_attribute(section: :main, header: 'Ended at') do |job, verbose:|
-      if job.end_time.nil?
-        nil
-      elsif verbose
-        job.end_time
-      else
-        DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
-      end
+    register_attribute(header: 'Ended at') do |job, verbose:|
+      job.format_end_time(verbose)
     end
 
     # NOTE: In interactive shells, the STDOUT/STDERR are merged together if they
@@ -113,9 +99,9 @@ module FlightJob
     #       affecting the ability to pad the output.
     #
     # PS: The 'path' mode is a misnomer, it refers solely to the standard output/error paths
-    register_attribute(section: :main, modes: [:paths], header: 'Stdout Path') { |j| j.stdout_path }
-    register_attribute(section: :main, modes: [:paths], header: 'Stderr Path') { |j| j.stderr_path }
-    register_attribute(section: :main, interactive: true, modes: [:combined], header: 'Output Path') { |j| j.stdout_path }
+    register_attribute(modes: [:paths], header: 'Stdout Path') { |j| j.stdout_path }
+    register_attribute(modes: [:paths], header: 'Stderr Path') { |j| j.stderr_path }
+    register_attribute(interactive: true, modes: [:combined], header: 'Output Path') { |j| j.stdout_path }
 
     register_attribute(section: :submit, header: 'Submit Stdout') do |job|
       job.submit_stdout

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -72,22 +72,22 @@ module FlightJob
     end
 
     start_header = ->(job, verbose:) do
-      job.start_time || verbose ? 'Started at' : 'Estimated Start'
+      job.actual_start_time || verbose ? 'Started at' : 'Estimated Start'
     end
     register_attribute(header: start_header) do |job, verbose:|
-      if job.start_time || verbose
-        job.format_start_time(verbose)
+      if job.actual_start_time || verbose
+        job.format_actual_start_time(verbose)
       else
         job.format_estimated_start_time(false)
       end
     end
 
     end_header = ->(job, verbose:) do
-      job.end_time || verbose ? 'Ended at' : 'Estimated Finish'
+      job.actual_end_time || verbose ? 'Ended at' : 'Estimated Finish'
     end
     register_attribute(header: end_header) do |job, verbose:|
-      if job.end_time || verbose
-        job.format_end_time(verbose)
+      if job.actual_end_time || verbose
+        job.format_actual_end_time(verbose)
       else
         job.format_estimated_end_time(false)
       end

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -35,22 +35,13 @@ module FlightJob
       <%
         verbose = output.context[:verbose]
         main = output.callables.config_select(:section, :other)
-        paths = main.select(&:paths?)
-
-        # Determine if the STDOUT/STDERR paths should be combined or
-        # independently displayed
-        if verbose || paths.map { |p| p.call(model) }.uniq.length != 1
-          callables = OutputMode::Callables.new main.reject(&:combined?)
-        else
-          callables = OutputMode::Callables.new main.reject(&:paths?)
-        end
       -%>
-      <% callables.pad_each do |callable, padding:, field:| -%>
+      <% main.pad_each(:header, model, verbose) do |callable, padding:, field:| -%>
       <%
           # Generates the value
           # NOTE: The output contains details about how to handle nil/true/false
           value = pastel.green callable.generator(output).call(model)
-          header = pastel.blue.bold callable.config[:header]
+          header = pastel.blue.bold field
       -%>
       <%= padding -%><%= header -%><%= pastel.bold ':' -%> <%= value %>
       <% end -%>
@@ -84,24 +75,37 @@ module FlightJob
       end
     end
 
-    register_attribute(header: 'Started at') do |job, verbose:|
-      job.format_start_time(verbose)
+    start_header = ->(job, verbose) do
+      job.start_time || verbose ? 'Started at' : 'Estimated Start'
     end
-    register_attribute(header: 'Ended at') do |job, verbose:|
-      job.format_end_time(verbose)
+    register_attribute(header: start_header) do |job, verbose:|
+      if job.start_time || verbose
+        job.format_start_time(verbose)
+      else
+        job.format_estimated_start_time(false)
+      end
     end
 
-    # NOTE: In interactive shells, the STDOUT/STDERR are merged together if they
-    #       are the same. The 'modes' are boolean flags (similar to verbose/interactive)
-    #       which are used to select the appropriate attributes.
-    #
-    #       As each attribute is defined independently, the headers can be changed without
-    #       affecting the ability to pad the output.
-    #
-    # PS: The 'path' mode is a misnomer, it refers solely to the standard output/error paths
-    register_attribute(modes: [:paths], header: 'Stdout Path') { |j| j.stdout_path }
-    register_attribute(modes: [:paths], header: 'Stderr Path') { |j| j.stderr_path }
-    register_attribute(interactive: true, modes: [:combined], header: 'Output Path') { |j| j.stdout_path }
+    end_header = ->(job, verbose) do
+      job.end_time || verbose ? 'Ended at' : 'Estimated Finish'
+    end
+    register_attribute(header: end_header) do |job, verbose:|
+      if job.end_time || verbose
+        job.format_end_time(verbose)
+      else
+        job.format_estimated_end_time(false)
+      end
+    end
+
+    path_header = ->(job, verbose) do
+      if job.stdout_path == job.stderr_path && !verbose
+        'Output Path'
+      else
+        'Stdout Path'
+      end
+    end
+    register_attribute(header: path_header) { |j| j.stdout_path }
+    register_attribute(header: 'Stderr Path', verbose: true) { |j| j.stderr_path }
 
     register_attribute(section: :submit, header: 'Submit Stdout') do |job|
       job.submit_stdout
@@ -116,7 +120,13 @@ module FlightJob
     # The submit columns will always be sorted to the bottom in the interactive outputs.
     #
     # Consider reordering on the next major version bump.
-    register_attribute(section: :main, header: 'Results Dir') { |j| j.results_dir }
+    register_attribute(header: 'Results Dir') { |j| j.results_dir }
+    register_attribute(verbose: true, header: 'Estimated Start') do |job|
+      job.format_estimated_start_time(true)
+    end
+    register_attribute(verbose: true, header: 'Estimated Finish') do |job|
+      job.format_estimated_end_time(true)
+    end
 
     def self.build_output(**opts)
       submit = opts.delete(:submit)

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -50,25 +50,11 @@ module FlightJob
       end
     end
 
-    # NOTE: These could be the predicted times instead of the actual, consider
-    # delineating the two
     register_column(header: 'Started at') do |job, verbose:|
-      if job.start_time.nil?
-        nil
-      elsif verbose
-        job.start_time
-      else
-        DateTime.rfc3339(job.start_time).strftime('%d/%m/%y %H:%M')
-      end
+      job.format_actual_start_time(verbose)
     end
     register_column(header: 'Ended at') do |job, verbose:|
-      if job.end_time.nil?
-        nil
-      elsif verbose
-        job.end_time
-      else
-        DateTime.rfc3339(job.end_time).strftime('%d/%m/%y %H:%M')
-      end
+      job.format_actual_end_time(verbose)
     end
 
     register_column(header: 'StdOut Path', verbose: true) { |j| j.stdout_path }

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -75,6 +75,9 @@ module FlightJob
     register_column(header: 'StdErr Path', verbose: true) { |j| j.stderr_path }
     register_column(header: 'Results Dir', verbose: true) { |j| j.results_dir }
 
+    register_column(header: 'Estimated Start', verbose: true, &:estimated_start_time)
+    register_column(header: 'Estimated Finish', verbose: true, &:estimated_end_time)
+
     def self.build_output(**opts)
       if opts.delete(:json)
         JSONRenderer.new(true, opts[:interactive])

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -136,6 +136,14 @@ if [[ "$end_time" == "Unknown" ]] ; then
 fi
 
 # Render and return the payload
+# NOTE: There is no "$estimated_end_time" variable because it is the same as "$end_time"
+#       The "$estimated_start_time"/"$start_time" distinguish exists to account for jobs
+#       without an allocation
+#
+#       The allocation isn't important for the end_time, which is inferred from the '$state'
+#
+# NOTE: flight-job will only set the start/end times if the job is within the correct state,
+#       This means state checks are not required within this script.
 echo '{}' | jq  --arg state "$state" \
                 --arg reason "$reason" \
                 --arg estimated_start_time "$estimated_start_time" \

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -48,7 +48,7 @@ read -r -d '' template <<'TEMPLATE' || true
   start_time: ($start_time),
   end_time: ($end_time),
   estimated_start_time: ($estimated_start_time),
-  estimated_end_time: ($end_time)
+  estimated_end_time: ($estimated_end_time)
 }
 TEMPLATE
 
@@ -135,6 +135,10 @@ if [[ "$end_time" == "Unknown" ]] ; then
   end_time=""
 fi
 
+# Slurm does not make the distinguish between estimated/actual end times clear.
+# Instead flight-job will infer which one is correct from the state mapping file
+estimated_end_time="$end_time"
+
 # Render and return the payload
 # NOTE: There is no "$estimated_end_time" variable because it is the same as "$end_time"
 #       The "$estimated_start_time"/"$start_time" distinguish exists to account for jobs
@@ -147,6 +151,7 @@ fi
 echo '{}' | jq  --arg state "$state" \
                 --arg reason "$reason" \
                 --arg estimated_start_time "$estimated_start_time" \
+                --arg estimated_end_time "$estimated_end_time" \
                 --arg start_time "$start_time" \
                 --arg end_time "$end_time" \
                 "$template" | tr -d "\n"

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -39,12 +39,16 @@ which "jq" >/dev/null
 set +e
 
 # Specify the template for the JSON response
+# NOTE: scontrol does not distinguish between actual/estimated times. Instead
+#       flight-job will set the times according to the state
 read -r -d '' template <<'TEMPLATE' || true
 {
   state: ($state),
   reason: ($reason),
-  start_time: (if $start_time == "" then null else $start_time end),
-  end_time: (if $end_time == "" then null else $end_time end)
+  start_time: ($start_time),
+  end_time: ($end_time),
+  estimated_start_time: ($estimated_start_time),
+  estimated_end_time: ($end_time)
 }
 TEMPLATE
 
@@ -64,12 +68,13 @@ if [[ "$exit_status" -eq 0 ]]; then
     reason=""
   fi
 
+  estimated_start_time=$(echo "$control" | grep '^StartTime=' | cut -d= -f2)
   if [[ "$(echo "$control" | grep "^NodeList=" | cut -d= -f2)" == "(null)" ]]; then
     # Skip setting the start_time when there is no allocation
     start_time=""
   else
     # Set the start_time if nodes where allocated to the job
-    start_time=$(echo "$control" | grep '^StartTime=' | cut -d= -f2)
+    start_time="$estimated_start_time"
   fi
 
   end_time=$(  echo "$control" | grep '^EndTime='   | cut -d= -f2)
@@ -105,6 +110,10 @@ elif [[ "$exit_status" -eq 0 ]]; then
   fi
   end_time=$(echo "$acct" | cut -d'|' -f4)
 
+  # The job will be in a terminal state if in sacct and thus the
+  # estimated_start_time is not important.
+  estimated_start_time=''
+
   # Exit the monitor process if sacct fails to prevent the job being updated
   else
     echo "$sacct" >&3
@@ -119,6 +128,9 @@ fi
 if [[ "$start_time" == "Unknown" ]] ; then
   start_time=""
 fi
+if [[ "$estimated_start_time" == "Unknown" ]] ; then
+  estimated_start_time=""
+fi
 if [[ "$end_time" == "Unknown" ]] ; then
   end_time=""
 fi
@@ -126,6 +138,7 @@ fi
 # Render and return the payload
 echo '{}' | jq  --arg state "$state" \
                 --arg reason "$reason" \
+                --arg estimated_start_time "$estimated_start_time" \
                 --arg start_time "$start_time" \
                 --arg end_time "$end_time" \
                 "$template" | tr -d "\n"

--- a/libexec/slurm/monitor.sh
+++ b/libexec/slurm/monitor.sh
@@ -135,19 +135,15 @@ if [[ "$end_time" == "Unknown" ]] ; then
   end_time=""
 fi
 
-# Slurm does not make the distinguish between estimated/actual end times clear.
-# Instead flight-job will infer which one is correct from the state mapping file
+# NOTE: Slurm does not make the distinguish between estimated/actual end times clear.
+#       Instead flight-job will infer which one is correct from the state mapping file
+#
+#       A similar principle is used to distinguish between the estimated/actual start
+#       times. The main difference being, jobs without an "allocation" will not have
+#       an "actual" start_time. This is because slurm sets a StartTime when the job
+#       is cancelled even when PENDING.
 estimated_end_time="$end_time"
 
-# Render and return the payload
-# NOTE: There is no "$estimated_end_time" variable because it is the same as "$end_time"
-#       The "$estimated_start_time"/"$start_time" distinguish exists to account for jobs
-#       without an allocation
-#
-#       The allocation isn't important for the end_time, which is inferred from the '$state'
-#
-# NOTE: flight-job will only set the start/end times if the job is within the correct state,
-#       This means state checks are not required within this script.
 echo '{}' | jq  --arg state "$state" \
                 --arg reason "$reason" \
                 --arg estimated_start_time "$estimated_start_time" \


### PR DESCRIPTION
Because `scontrol` does not distinguish between "predicted" and "actual" start times, the state has to be interrogated to determine which one it is. This is done by `flight-job` ruby code as it has access to the state map.

The `submit.sh` script may always report a estimated start/end time and allow `flight-job` to determine how to handle it. The estimated start time can only updated in the `PENDING` state, after this point thus job has started and thus no more predictions are required. Similarly, the estimated finished time can only be updated in a `PENDING` or `RUNNING` state.