### PR TITLE
Change `output_dir` to `results_dir` and allow env vars

### DIFF
--- a/etc/flight-job.yaml
+++ b/etc/flight-job.yaml
@@ -28,6 +28,7 @@
 # ==============================================================================
 # Templates Directory
 # Specify where the templates will be stored.
+# The environment variable flight_JOB_templates_dir takes precedence.
 #
 # Relative paths are expanded from the install directory.
 # ==============================================================================
@@ -38,6 +39,8 @@
 # Specify where the scripts will be stored.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_scripts_dir takes precedence.
 # ==============================================================================
 # scripts_dir: ~/.local/share/flight/job/scripts
 
@@ -46,14 +49,18 @@
 # Specify where the scripts will be stored.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_jobs_dir takes precedence.
 # ==============================================================================
-# scripts_dir: ~/.local/share/flight/job/jobs
+# jobs_dir: ~/.local/share/flight/job/jobs
 
 # ==============================================================================
 # Submit Script Path
 # Specify the path to the script which submits jobs.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_submit_script_path takes precedence.
 # ==============================================================================
 # submit_script_path: libexec/slurm/monitor.sh
 
@@ -62,6 +69,8 @@
 # Specify the path to the script which monitors jobs.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_monitor_script_path takes precedence.
 # ==============================================================================
 # monitor_script_path: libexec/slurm/monitor.sh
 
@@ -74,6 +83,8 @@
 #
 # WARNING: Unrecognized flight-job states may prevent the job from being updated.
 # Ensure all flight-job states are valid (see: lib/flight_job/models/script.rb)
+#
+# The environment variable flight_JOB_state_map_path takes precedence.
 # ==============================================================================
 # state_map_path: etc/state-maps/slurm.yaml
 
@@ -86,6 +97,8 @@
 # the "flight job run-monitor" command periodically.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_check_cron takes precedence.
 # ==============================================================================
 # check_cron: libexec/check-cron.sh
 
@@ -94,12 +107,16 @@
 # The minimum terminal width when wrapping output text. This prevents various
 # edge cases in small terminals. The terminal is responsible for wrapping the
 # text if its width is smaller than the minimum.
+#
+# The environment variable flight_JOB_minimum_terminal_width takes precedence.
 # ==============================================================================
 # minimum_terminal_width: 80
 
 # ==============================================================================
 # Maximum ID Length
 # The maximum allowed length for script IDs
+#
+# The environment variable flight_JOB_max_id_length takes precedence.
 # ==============================================================================
 # max_id_length: 16
 
@@ -107,6 +124,8 @@
 # Maximum Standard Input Size
 # The maximum file size that will be provided to STDIN. The size must be given
 # in Bytes.
+#
+# The environment variable flight_JOB_stdin_size takes precedence.
 # ==============================================================================
 # max_stdin_size: 1048576 # (1 MB)
 
@@ -114,6 +133,8 @@
 # Submission Period
 # The minimum amount of time to wait before a job that is "pending submission"
 # is considered failed.
+#
+# The environment variable flight_JOB_submission_period takes precedence.
 # ==============================================================================
 # submission_period: 3600
 
@@ -123,6 +144,8 @@
 # omitted.
 #
 # Relative paths are expanded from the install directory.
+#
+# The environment variable flight_JOB_log_path takes precedence.
 # ==============================================================================
 # log_path: ~/.cache/flight/log/share/job.log
 
@@ -130,5 +153,7 @@
 # Log level
 # Set at which severity the application will log
 # Valid levels: 'fatal', 'error', 'warn', 'info', 'debug'
+#
+# The environment variable flight_JOB_log_level takes precedence.
 # ==============================================================================
 # log_level: warn

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -187,5 +187,13 @@ module FlightJob
         end
       end
     end
+
+    def assert_results_dir_exists(job)
+      # NOTE: Jobs created with old versions of flight-job will not have a
+      # results directory.
+      unless job.results_dir
+        raise MissingError, "The job did not report its results directory"
+      end
+    end
   end
 end

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -29,21 +29,13 @@ module FlightJob
   module Commands
     class ListJobResults < Command
       def run
-        @job = load_job(args.first)
-        assert_results_dir_exists
-        FlightJob.logger.debug "Running: ls #{@job.results_dir} #{ls_options.join(" ")}"
-        Kernel.system('ls', @job.results_dir, *ls_options)
+        job = load_job(args.first)
+        assert_results_dir_exists(job)
+        FlightJob.logger.debug "Running: ls #{job.results_dir} #{ls_options.join(" ")}"
+        Kernel.system('ls', job.results_dir, *ls_options)
       end
 
       private
-
-      def assert_results_dir_exists
-        # NOTE: Jobs created with old versions of flight-job will not have an
-        # results directory.
-        unless @job.results_dir
-          raise MissingError, "The job did not report its results directory"
-        end
-      end
 
       def ls_options
         @ls_options ||= begin

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -30,18 +30,18 @@ module FlightJob
     class ListJobResults < Command
       def run
         @job = load_job(args.first)
-        assert_output_dir_exists
-        FlightJob.logger.debug "Running: ls #{@job.output_dir} #{ls_options.join(" ")}"
-        Kernel.system('ls', @job.output_dir, *ls_options)
+        assert_results_dir_exists
+        FlightJob.logger.debug "Running: ls #{@job.results_dir} #{ls_options.join(" ")}"
+        Kernel.system('ls', @job.results_dir, *ls_options)
       end
 
       private
 
-      def assert_output_dir_exists
+      def assert_results_dir_exists
         # NOTE: Jobs created with old versions of flight-job will not have an
-        # output directory.
-        unless @job.output_dir
-          raise MissingError, "The job did not report its output directory"
+        # results directory.
+        unless @job.results_dir
+          raise MissingError, "The job did not report its results directory"
         end
       end
 

--- a/lib/flight_job/commands/view_job_output.rb
+++ b/lib/flight_job/commands/view_job_output.rb
@@ -48,8 +48,9 @@ module FlightJob
         if @job.stdout_path == @job.stderr_path
           prog_name = ENV.fetch('FLIGHT_PROGRAM_NAME') { 'bin/job' }
           raise MissingError, <<~ERROR.chomp
-            Cannot display the job's standard error as it has been merged with standard output.
-            Run '#{prog_name} view-job-stdout #{@job.id}` to view the job's output.
+            Cannot display the job's standard error as it has been merged with standard out.
+            Please run the following instead:
+            #{pastel.yellow "#{prog_name} view-job-stdout #{@job.id}"}
           ERROR
         end
       end

--- a/lib/flight_job/commands/view_job_results.rb
+++ b/lib/flight_job/commands/view_job_results.rb
@@ -30,18 +30,18 @@ module FlightJob
     class ViewJobResults < Command
       def run
         @job = load_job(args.first)
-        assert_output_dir_exists
-        file_path = File.join(@job.output_dir, args[1])
+        assert_results_dir_exists
+        file_path = File.join(@job.results_dir, args[1])
         assert_file_exists(file_path)
         pager.page(File.read(file_path))
       end
 
       private
 
-      def assert_output_dir_exists
+      def assert_results_dir_exists
         # NOTE: Jobs created with old versions of flight-job will not have an
         # output directory.
-        unless @job.output_dir
+        unless @job.results_dir
           raise MissingError, "The job did not report its output directory"
         end
       end

--- a/lib/flight_job/commands/view_job_results.rb
+++ b/lib/flight_job/commands/view_job_results.rb
@@ -29,22 +29,14 @@ module FlightJob
   module Commands
     class ViewJobResults < Command
       def run
-        @job = load_job(args.first)
-        assert_results_dir_exists
-        file_path = File.join(@job.results_dir, args[1])
+        job = load_job(args.first)
+        assert_results_dir_exists(job)
+        file_path = File.join(job.results_dir, args[1])
         assert_file_exists(file_path)
         pager.page(File.read(file_path))
       end
 
       private
-
-      def assert_results_dir_exists
-        # NOTE: Jobs created with old versions of flight-job will not have an
-        # output directory.
-        unless @job.results_dir
-          raise MissingError, "The job did not report its output directory"
-        end
-      end
 
       def assert_file_exists(path)
         unless File.exists?(path)

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -41,13 +41,6 @@ module FlightJob
                  File.expand_path('etc/flight-job.local.yaml', root_path),
                  File.expand_path('~/.config/flight/flight-job.yaml')
 
-    # Disable environment variable overrides. This is to allow the API service
-    # to wrap the CLI without setting up the environment.
-    def self.attribute(*a, **opts)
-      opts[:env_var] = false
-      super(*a, **opts)
-    end
-
     attribute :templates_dir, default: 'usr/share',
               transform: relative_to(root_path)
     attribute :scripts_dir, default: '~/.local/share/flight/job/scripts',

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -36,6 +36,10 @@ module FlightJob
 
     root_path File.expand_path('../..', __dir__)
 
+    # XXX: This should probably be implicitly set by FlightConfiguration
+    # Maybe it is in a latter version?
+    env_var_prefix 'flight_JOB'
+
     config_files File.expand_path('etc/flight-job.yaml', root_path),
                  File.expand_path('etc/flight-job.development.yaml', root_path),
                  File.expand_path('etc/flight-job.local.yaml', root_path),

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -56,7 +56,7 @@ module FlightJob
         "scheduler_id" => { "type" => ["string", "null"] },
         "stdout_path" => { "type" => ["string", "null"] },
         "stderr_path" => { "type" => ["string", "null"] },
-        "output_dir" => { "type" => ["string", "null"] },
+        "results_dir" => { "type" => ["string", "null"] },
         "reason" => { "type" => ["string", "null"] },
         "start_time" => { "type" => ["string", "null"], "format" => "date-time" },
         "end_time" => { "type" => ["string", "null"], "format" => "date-time" }
@@ -76,12 +76,12 @@ module FlightJob
     SUBMIT_RESPONSE_SCHEMA = JSONSchemer.schema({
       "type" => "object",
       "additionalProperties" => false,
-      "required" => ["id", "stdout", "stderr", "output_dir"],
+      "required" => ["id", "stdout", "stderr", "results_dir"],
       "properties" => {
         "id" => { "type" => "string" },
         "stdout" => { "type" => "string" },
         "stderr" => { "type" => "string" },
-        "output_dir" => { "type" => "string" }
+        "results_dir" => { "type" => "string" }
       }
     })
 
@@ -260,7 +260,7 @@ module FlightJob
     [
       "submit_status", "submit_stdout", "submit_stderr", "script_id", "state",
       "scheduler_id", "scheduler_state", "stdout_path", "stderr_path", "reason",
-      "start_time", "end_time", "output_dir"
+      "start_time", "end_time", "results_dir"
     ].each do |method|
       define_method(method) { metadata[method] }
       define_method("#{method}=") { |value| metadata[method] = value }
@@ -321,7 +321,7 @@ module FlightJob
           self.scheduler_id = data['id']
           self.stdout_path = data['stdout']
           self.stderr_path = data['stderr']
-          self.output_dir = data['output_dir']
+          self.results_dir = data['results_dir']
         end
 
         # Persist the updated version of the metadata

--- a/lib/flight_job/outputs/info_job.rb
+++ b/lib/flight_job/outputs/info_job.rb
@@ -130,7 +130,7 @@ module FlightJob
     # The submit columns will always be sorted to the bottom in the interactive outputs.
     #
     # Consider reordering on the next major version bump.
-    register_attribute(section: :main, header: 'Results Dir') { |j| j.output_dir }
+    register_attribute(section: :main, header: 'Results Dir') { |j| j.results_dir }
 
     def self.build_output(**opts)
       submit = opts.delete(:submit)

--- a/lib/flight_job/outputs/list_jobs.rb
+++ b/lib/flight_job/outputs/list_jobs.rb
@@ -73,7 +73,7 @@ module FlightJob
 
     register_column(header: 'StdOut Path', verbose: true) { |j| j.stdout_path }
     register_column(header: 'StdErr Path', verbose: true) { |j| j.stderr_path }
-    register_column(header: 'Results Dir', verbose: true) { |j| j.output_dir }
+    register_column(header: 'Results Dir', verbose: true) { |j| j.results_dir }
 
     def self.build_output(**opts)
       if opts.delete(:json)

--- a/libexec/slurm/submit.sh
+++ b/libexec/slurm/submit.sh
@@ -46,7 +46,7 @@ read -r -d '' template <<'TEMPLATE' || true
   id: ($id),
   stdout: ($stdout),
   stderr: ($stderr),
-  output_dir: ($output_dir)
+  results_dir: ($results_dir)
 }
 TEMPLATE
 
@@ -84,11 +84,11 @@ stderr=$(echo "$control" | grep -E "^\s*StdErr=" | sed "s/^\s*StdErr=//g")
 # Determine the output directory
 working=$(echo "$control" | grep -E "^\s*WorkDir=" | sed "s/^\s*WorkDir=//g")
 name=$(echo "$control" | grep -E "^JobId=\w*\s*JobName=" | sed "s/^JobId=\w*\s*JobName=//g")
-output_dir="${working}/${name}-outputs/$id"
+results_dir="${working}/${name}-outputs/$id"
 
 # Render and return the JSON payload
 echo '{}' | jq  --arg id "$id" \
                 --arg stdout "$stdout" \
                 --arg stderr "$stderr" \
-                --arg output_dir "$output_dir" \
+                --arg results_dir "$results_dir" \
                 "$template" | tr -d "\n"


### PR DESCRIPTION
This PR makes two changes:

* Changes the metadata key from `output_dir` to `results_dir`, and
* Allows the application to be configured by `env_vars`