### PR TITLE
Exit 3 or 20 from  list-job-results if the directory exists

### DIFF
--- a/bin/job
+++ b/bin/job
@@ -55,9 +55,6 @@ begin
   # Runs the command within the original directory
   Dir.chdir(ENV.fetch('FLIGHT_CWD', '.')) do
     OpenFlight.set_standard_env rescue nil
-    # NOTE: flight-job uses ARGV internally in list-job-results
-    #       This *should not* cause a problem, but care will need to be taken
-    #       if this bin script is modified.
     FlightJob::CLI.run!(*ARGV)
   end
 rescue Interrupt

--- a/bin/job
+++ b/bin/job
@@ -55,6 +55,9 @@ begin
   # Runs the command within the original directory
   Dir.chdir(ENV.fetch('FLIGHT_CWD', '.')) do
     OpenFlight.set_standard_env rescue nil
+    # NOTE: flight-job uses ARGV internally in list-job-results
+    #       This *should not* cause a problem, but care will need to be taken
+    #       if this bin script is modified.
     FlightJob::CLI.run!(*ARGV)
   end
 rescue Interrupt

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -47,7 +47,15 @@ module FlightJob
         else
           # When soft wrapping, hide the ls error
           stdout, status = Open3.capture2(*cmd)
-          puts stdout if status.success?
+          if status.success? && stdout.empty?
+            if Job::TERMINAL_STATES.include?(job.state)
+              $stderr.puts pastel.yellow 'No job results found.'
+            else
+              $stderr.puts pastel.yellow 'No job results found, please try again latter...'
+            end
+          elsif status.success?
+            puts stdout
+          end
           status.success?
         end
 

--- a/lib/flight_job/commands/submit_job.rb
+++ b/lib/flight_job/commands/submit_job.rb
@@ -36,6 +36,9 @@ module FlightJob
         job.submit
         show_submit = job.submit_status != 0
         puts Outputs::InfoJob.build_output(submit: show_submit, **output_options).render(job)
+        unless job.submit_status == 0
+          raise GeneralError, "The job submission failed!"
+        end
       end
 
       def script


### PR DESCRIPTION
The command will return either `3`, `20`, or `23` if the results directory does not exist. These can be interpreted as:
* `23`: `load_job` failed as the `job` does not exist (Technically unrelated to `ls`),
* `20`: The `job` is in a terminal state and the directory does not exist, and
* `3`: The directory does not exist as the job is PENDING/RUNNING but it may exist in the future.

PENDING/RUNNING jobs are considered to be an `InputError` (exit 3) as the command was ran too early. It is unlikely any other input error will be possible on this command for two reasons:
* All other inputs are passed to `ls, and
* `ls` does not provide particularly useful error responses (without string parsing), it normally exists `2`.

---

The error message is not strictly dependent on the exit status for a couple of reasons.  Firstly it is fairly easy to break `ls` by running the command below. `ls` will (likely) error/exit 2 as the `foobar` directory does not exist. This means no useful information can be extracted about the `results_dir` and a generic error message is raised.

```
$ bin/job job list-job-results SCRIPT_ID foobar
ls: cannot access foobar: No such file or directory
...
bin/job: An error occurred when running the 'ls' command!
$ echo $?
20
```

*NOTE*: Assuming the `ls` command is valid, the exit code specification is still correct

For the single argument version of the command, the error depends on the job's `state`:

```
# PENDING jobs
$ bin/job job list-job-results SCRIPT_ID
bin/job: Your job has not started yet, please try again later...

# RUNNING jobs
bin/job: Your job is currently running, please try again later...

# TERMINAL jobs
bin/job: Your job did not create the results directory!
```