### PR TITLE
Standardise the config and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,21 @@ To prevent this, the `run-monitor` command should be ran periodically for each u
 
 \*\* NOTE: Custom `scheduler` implementations should also transition missing jobs to an `UNKNOWN` state. Failure to do so will cause them to get stuck in the "last known state".
 
+# Versioning
+
+This application uses [semver](https://semver.org/) to version the command line interface. The current version is given within [version.rb](lib/flight_job/version.rb). This version is limited to the applications _public command line interface _(exhaustive list):
+
+* The command names and associated aliases,
+* The commands' type signatures,
+* The commands' option flags (unless otherwise stated),
+* The column order of the machine readable index outputs,
+* The key names of the machine readable show outputs,
+* The required keys within the JSON outputs (\*\* pending specification)
+
+\* _Note for system integrators_
+
+The internal metadata files and scripts are independently versioned. These scripts have a major version number which denotes they are backwards compatible. Additional required keys will not be added within a major version number, however recommended keys maybe.
+
 # Contributing
 
 Fork the project. Make your feature addition or bug fix. Send a pull

--- a/README.md
+++ b/README.md
@@ -1,189 +1,183 @@
 # Flight Job
 
-Generate a job script from a predefined template
+Generate job scripts from predefined templates and submit them to a HPC
+scheduler.
 
-## Prerequisite
+## Overview
 
-This applications requires `ruby` version `2.7.1` and `bundler` `2.1.4`. This guide will assume that `ruby` and `bundler` are on your `PATH`, however absolute paths to the binaries are also supported.
-
-By default, this application ships with `slurm` integration scripts. These scripts assume that `sbatch`,`scontrol`, etc.. are on your `PATH`. The integration scripts also require `jq` (version `1.6`) to be in your `PATH`. See [configuration](#configuration) for full details.
-
-*Summary*:
-* `ruby`
-* `bundler`
-* `slurm` - `scontrol`,`sbatch`,..
-* `jq`
+Flight Job facilitates the creation of complex job scripts from predefined
+templates.  Job scripts are created by answering a number of questions defined
+by the template.  Once created, Flight Job can submit the job script to the
+cluster's HPC scheduler and provide support for managing the job and accessing
+its results.
 
 ## Installation
 
-*User Suite Install*
+### Installing with the OpenFlight package repos
 
-This package is available as part of the *OpenFlight - User Suite* as an rpm. This is the easiest method for installing `flight-job` and all required dependencies.
+Flight Job is available as part of the *Flight User Suite*.  This is the
+easiest method for installing Flight Job and all its dependencies.  It is
+documented in [the OpenFlight
+Documentation](https://use.openflighthpc.org/installing-user-suite/install.html#installing-flight-user-suite).
 
-[Refer to the OpenFlight project for further details](https://use.openflighthpc.org/installing-user-suite/install.html).
+### Manual Installation
 
-*Manual Install*
+#### Prerequisites
 
-Before proceeding, you will need a version of `ruby` `2.7.1`. You _may_ be able to run the application with a different ruby version, however you mileage may vary. [Refer to rvm documentation on how to install rub](https://rvm.io/).
+Flight Job is developed and tested with Ruby version `2.7.1` and `bundler`
+`2.1.4`.  Other versions may work but currently are not officially supported.
 
-By default, `flight-job` will need an install of `slurm` and `jq`. These packages maybe available via your package manager. Alternatively, they can be downloaded from: [slurm download](https://www.schedmd.com/downloads.php) and [jq download](https://stedolan.github.io/jq/download/).
+#### Install Flight Job
 
-`flight-job` should then be cloned via `git` and gems installed with `bundler`. The `master` branch is the current bleeding edge version and is not appropriate for production installs. Instead a tagged version should be checked out.
-
-*Example Manual Slurm Installation*
+The following will install from source using `git`.  The `master` branch is
+the current development version and may not be appropriate for a production
+installation. Instead a tagged version should be checked out.
 
 ```
-# Install and configure slurm according to your requirments
-
-# Install jq
-cd /path/to/jq/bin
-wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-mv jq-linux64 jq
-chmod u+x jq
-
-# jq will need to be on your PATH, consider adding to your .bashrc
-export PATH=$PATH:$(pwd)
-
-# Install flight-job
-cd /path/to/parent-dir
-git clone https://github.com/openflighthpc/flight-job
+git clone https://github.com/alces-flight/flight-job.git
 cd flight-job
 git checkout <tag>
-
-# Install the production gems
-bundle install --with default --without development
-
-# Install the development gems (optional)
-bundle install --with default --with development
+bundle config set --local with default
+bundle config set --local without development
+bundle install
 ```
+
+The manual installation of Flight Job comes preconfigured to run in
+development mode.  If installing Flight Job manually for production usage you
+will want to follow the instructions to [set the environment
+mode](/docs/environment-modes.md) to `standalone`.
+
+Use the script located at `bin/job` to execute the tool.
+
+#### Install a HPC scheduler
+
+By default, Flight Job ships with [Slurm](https://slurm.schedmd.com/)
+integration scripts.  The integration scripts require
+[jq](https://stedolan.github.io/jq/) to be installed.
+
+These packages may be available for installation via your package manager.
+Alternatively, you can follow the [slurm installation
+instructions](https://slurm.schedmd.com/download.html) and the [jq
+installation instructions](https://stedolan.github.io/jq/download/).  If
+installing manually, make sure that the Slurm binaries and the jq binary are
+on your PATH.
+
 
 ## Configuration
 
-The github repo is preconfigured to run the application in development mode. This will cause the `flight_ROOT` environment variable to be ignored. The production behaviour can be achieved with:
+Flight Job comes preconfigured to work with Slurm without further
+configuration.  Please refer to the [configuration file](etc/job.yaml)
+for a full list of configuration options.
 
-```
-export flight_ENVIRONMENT=production
-export flight_ROOT=...
-```
-Please refer to the [reference configuration](etc/job.yaml) for a full list of configuration options.
 
-### Environment Overview
+### Environment Modes
 
-`flight-job` has three supported environments in which it can operate in `production`, `standalone`, and `development`. By default the git repo will be configured to use `development`. They can be summaries as:
-
-* `production`  - Runs with the production gems and respects `flight_ROOT`,
-* `standalone`  - Runs with the production gems but ignores `flight_ROOT`, or
-* `development` - Runs with the development gems and ignores `flight_ROOT`.
-
-A "production" install should use either the `production` or `standalone` environments. In `production` the `flight_ROOT` environment variable is used to expand relative paths. The `flight_ROOT` environment variable should be set when using the `production` environment; otherwise the behaviour is the same as `standalone`. For example, the `production` environment will use the following paths:
-
-* `$flight_ROOT/etc/job.yaml`
-* `$flight_ROOT/usr/share/job/templates`
-* ... etc ...
-
-Both the `standalone` and `development` environments will ignore `$flight_ROOT` environment variable. Instead the will expand the paths from the "install directory":
-
-* `/path/to/flight-job/etc/job.yaml`
-* `/path/to/flight-job/usr/share/job/templates`
-* ... etc ...
-
-The environment can be set by either setting `flight_ENVIRONMENT` or overriding the `.env.development` file:
-
-```
-# Either option will set the enviroment
-export flight_ENVIRONMENT=<env>
-echo flight_ENVIRONMENT=<env> > .env.development.local
-```
-
-### Adding Custom Templates
-
-The `templates_dir` in the configuration specifies the location that templates should be stored. This will either be:
-
-* `$flight_ROOT`/usr/share/job/templates, or
-* `/path/to/flight-job/usr/share/job/templates`.
-
-A `template` must contain a `metadata.yaml` and associated "script template". Please refer to the [example templates](usr/share/templates/simple) for the specification.
-
-### Custom Scheduler Integrations
-
-By default, `flight-job` has been designed to integrate with `slurm` as its scheduler. It is however possible to reconfigure the application to work with a custom scheduler. Firstly the `submit_script_path` and `monitor_script_path` need to be updated in the `job.yaml` (`job.local.yaml` if using a git checkout):
-
-```
-submit_script_path: /path/to/custom/libexec/submit.sh
-monitor_script_path: /path/to/custom/libexec/monitor.sh
-```
-
-The `submit` script is responsible for submitting the job to the external scheduler and should return generic information about the job. The `monitor` script is ran to update the internal cache about the job.
-
-Both scripts receive a single argument which is used to identify the script/job. Additional arguments _may_ be provided in a future minor release.
-
-* `submit.sh`:  `$1` is the path to the rendered script for the job to be submitted, and
-* `monitor.sh`: `$1` is the scheduler generated ID of the job to be monitored.
-
-Both scripts use the final line of STDOUT as a means to communicate back to `flight-job`. This line must be in a JSON string according to the script's specification. These specifications are independently versioned from the CLI and may change on a minor release. The specification is defined using [JSON Schema](https://json-schema.org/understanding-json-schema/index.html):
-
-* [Submit Script Response Specification](lib/flight_job/models/job/submit_response_schema.yaml)
-* [Monitor Script Response Specification](lib/flight_job/models/job/monitor_response_schema.yaml)
-
-The scripts may print to both STDOUT and STDERR as a means of logging. Whether these logs are kept depends on the `log_level` specified in the configuration. Care needs to be taken when printing to STDOUT, as the last line must be the JSON response.
+If Flight Job has been installed manually for production usage you
+will want to follow the instructions to [set the environment
+mode](docs/environment-modes.md) to `standalone`.
 
 ## Operation
 
-The following will list the available templates
-NOTE: The behaviour is undefined if no templates are available
+A brief usage guide is given below.  More details can be found by running
+`bin/job --help`.  If Flight Job was installed via the OpenFlight package
+repos, you can read more detailed usage instructions by running `flight howto
+show flight job`.
+
+List the available templates.
 
 ```
-flight job list
+bin/job list-templates 
 ```
 
-The copy command is used to copy a template to another directory. By default it will copy to the current directory using the original file name.
+Create a job script from the template `simple`.
 
 ```
-# Copy to the current directory
-$ fight job copy simple.sh
-Successfully copied the template to: /root/simple.sh
-
-# Change the name
-$ flight job copy simple.sh demo.sh
-Successfully copied the template to: /root/demo.sh
-
-# Change the directory
-$ flight job copy simple.sh /tmp
-Successfully copied the template to: /tmp/simple.sh
-
-# Handles duplicate files
-$ flight job copy simple.sh
-Successfully copied the template to: /root/simple.sh.1
-
-# Allows copy by index
-$ flight job copy 3
-Successfully copied the template to: /root/simple.sh.2
+bin/job create-script simple
 ```
 
-### Updating the Internal Job Cache
+List your scripts.
 
-The "internal job cache" will be update on an ad hoc basis. This will typically be when `info-job` or `list-jobs` is ran.
+```
+bin/job list-scripts
+```
 
-Depending on your schedulers configuration, this may result in inconsistent updating behaviour. The external scheduler may periodically purge its records of historic jobs; preventing `flight-job` updating its internal cache. In the case of the default `slurm` scripts, the `jobs` will be transitioned into an `UNKNOWN` state (\*\*).
+Submit the script `simple-1`.
 
-To prevent this, the `run-monitor` command should be ran periodically for each user which has submitted jobs via `flight-job`. This can be done using `crontabs` or other appropriate deamon. 
+```
+bin/job submit simple-1
+```
 
-\*\* NOTE: Custom `scheduler` implementations should also transition missing jobs to an `UNKNOWN` state. Failure to do so will cause them to get stuck in the "last known state".
+List your jobs.
+
+```
+bin/job list-jobs
+```
+
+Show details about the job `n0XYc-Vt`.
+
+```
+bin/job info-job n0XYc-Vt
+```
+
+View the standard output for job `n0XYc-Vt`.
+
+```
+bin/job view-job-stdout n0XYc-Vt
+```
+
+List the results directory for job `n0XYc-Vt`.
+
+```
+bin/job ls-job-results n0XYc-Vt
+```
+
+View the results file `test.output` for job `n0XYc-Vt`.
+
+```
+bin/job view-job-results n0XYc-Vt test.output
+```
+
+## Adding Custom Templates
+
+Flight Job contains a number of [example templates](usr/share/job/templates/),
+which are enabled by default.  Custom templates can be created by following
+the [custom templates](docs/custom-templates.md) documentation.
+
+## Scheduler Integrations
+
+By default, Flight Job integrates with the Slurm HPC scheduler.  It is
+possible to configure Flight job to integrate with another scheduler.  See the
+[scheduler integrations](/docs/scheduler-integration.md) documentation for
+details on how to do so.
+
+
+## Periodic house keeping
+
+Flight Job maintains its own record about the jobs it submits to the HPC
+scheduler allowing Flight Job to provide details about a job long after the
+HPC scheduler has discarded its own record.
+
+Flight Job updates its records during normal usage and under normal usage
+patterns it is expected that Flight Job will always be able to monitor the job
+until it either completes or fails in some way.
+
+However, if the HPC scheduler is configured so that it doesn't maintain job
+records for very long, Flight Job may become unable to correctly update its
+records about some jobs.  If this occurs, the job will transition to an
+`UNKNOWN` state and certain data about it may not be available including its
+start time, end time, the reason it failed (if indeeded it did).
+
+The job's STDOUT, STDERR and results directory will be unaffected by this.
+
+To work around this edge case, the `run-monitor` command can be periodically
+ran for all users of Flight Job.  This could be done by creating a system
+`cron` task or creating user `crontabs`.
+
 
 # Versioning
 
-This application uses [semver](https://semver.org/) to version the command line interface. The current version is given within [version.rb](lib/flight_job/version.rb). This version is limited to the applications _public command line interface _(exhaustive list):
-
-* The command names and associated aliases,
-* The commands' type signatures,
-* The commands' option flags (unless otherwise stated),
-* The column order of the machine readable index outputs,
-* The key names of the machine readable show outputs,
-* The required keys within the JSON outputs (\*\* pending specification)
-
-\* _Note for system integrators_
-
-The internal metadata files and scripts are independently versioned. These scripts have a major version number which denotes they are backwards compatible. Additional required keys will not be added within a major version number, however recommended keys maybe.
+This application uses [semver](https://semver.org/).  The [versioning
+document](/docs/versioning.md) contains more details.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Both scripts receive a single argument which is used to identify the script/job.
 * `submit.sh`:  `$1` is the path to the rendered script for the job to be submitted, and
 * `monitor.sh`: `$1` is the scheduler generated ID of the job to be monitored.
 
-Both scripts use the final line of STDOUT as a means to communicate back to `flight-job`. This line must be in a JSON string according to the script's specification. These specifications are not considered part of `flight-job` public interface and maybe updated within a minor release. The specification is defined using [JSON Schema](https://json-schema.org/understanding-json-schema/index.html):
+Both scripts use the final line of STDOUT as a means to communicate back to `flight-job`. This line must be in a JSON string according to the script's specification. These specifications are independently versioned from the CLI and may change on a minor release. The specification is defined using [JSON Schema](https://json-schema.org/understanding-json-schema/index.html):
 
 * [Submit Script Response Specification](lib/flight_job/models/job/submit_response_schema.yaml)
 * [Monitor Script Response Specification](lib/flight_job/models/job/monitor_response_schema.yaml)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,29 @@ The `templates_dir` in the configuration specifies the location that templates s
 
 A `template` must contain a `metadata.yaml` and associated "script template". Please refer to the [example templates](usr/share/templates/simple) for the specification.
 
+### Custom Scheduler Integrations
+
+By default, `flight-job` has been designed to integrate with `slurm` as its scheduler. It is however possible to reconfigure the application to work with a custom scheduler. Firstly the `submit_script_path` and `monitor_script_path` need to be updated in the `job.yaml` (`job.local.yaml` if using a git checkout):
+
+```
+submit_script_path: /path/to/custom/libexec/submit.sh
+monitor_script_path: /path/to/custom/libexec/monitor.sh
+```
+
+The `submit` script is responsible for submitting the job to the external scheduler and should return generic information about the job. The `monitor` script is ran to update the internal cache about the job.
+
+Both scripts receive a single argument which is used to identify the script/job. Additional arguments _may_ be provided in a future minor release.
+
+* `submit.sh`:  `$1` is the path to the rendered script for the job to be submitted, and
+* `monitor.sh`: `$1` is the scheduler generated ID of the job to be monitored.
+
+Both scripts use the final line of STDOUT as a means to communicate back to `flight-job`. This line must be in a JSON string according to the script's specification. These specifications are not considered part of `flight-job` public interface and maybe updated within a minor release. The specification is defined using [JSON Schema](https://json-schema.org/understanding-json-schema/index.html):
+
+* [Submit Script Response Specification](lib/flight_job/models/job/submit_response_schema.yaml)
+* [Monitor Script Response Specification](lib/flight_job/models/job/monitor_response_schema.yaml)
+
+The scripts may print to both STDOUT and STDERR as a means of logging. Whether these logs are kept depends on the `log_level` specified in the configuration. Care needs to be taken when printing to STDOUT, as the last line must be the JSON response.
+
 ## Operation
 
 The following will list the available templates

--- a/docs/custom-templates.md
+++ b/docs/custom-templates.md
@@ -1,0 +1,340 @@
+# Adding Custom Templates
+
+The list of templates available are loaded from the directory given by the
+`templates_dir` configuration.  By default, these will be the [example
+templates](/usr/share/job/templates/) that ship with Flight Job.  If they are
+not suitable, you can change `templates_dir` to some other directory and
+create your own templates in that directory.
+
+## Different templates for different users
+
+The list of available templates can be configured independently for each user.
+To do so, set the `templates_dir` configuration appropriately for each user in
+their user-specific configuration file, `~/.config/flight/job.yaml`.
+
+If `templates_dir` is not set for a user, the value set in the global
+configuration file will be used.
+
+## Template format
+
+Each template is contained in its own subdirectory of `templates_dir` and
+contains the following files:
+
+* `metadata.yaml`: metadata about the template along with any questions used
+  to generate a job script.
+* `directives.<scheduler>.erb`: an
+  [ERb](https://ruby-doc.org/stdlib-2.7.1/libdoc/erb/rdoc/ERB.html) file
+  rendering to directives suitable for `<scheduler>`.
+* `workload.erb`: an ERb file rendering to the job script workload.
+
+### `metadata.yaml`
+
+`metadata.yaml` contains two sections.  The first is the general metadata
+about template, and the second are the template's questions.
+
+A commented example of the metadata is below.  The required keys are
+`version`, `name`, `synopsis`, `copyright`, `license` and
+`generation_questions` (more on this later).
+
+```yaml
+# The schema version for this template.  Currently, only version `0` is
+# supported.
+version: 0
+
+# The name of the template.
+name: Example template
+
+# A brief single-line description of the template.
+synopsis: An example template that exists for illustrative purposes.
+
+# A more detailed description of the template, possibly spanning multiple
+# lines.
+description: |
+  This is an example template that has been created to illustrate the template
+  file format.
+
+  A useful description would detail how to use the template and the job
+  scripts that it creates.
+
+  The Flight Job Webapp supports rendering
+  [Markdown](https://www.markdownguide.org/) in this descripton.
+
+# The copyright and license for this template.
+copyright: Copyright (C) 2021 Alces Flight Ltd.
+license: Creative Commons Attribution-ShareAlike 4.0 International
+
+# The relative sort order for the template.  Templates with lower values
+# appear before templates with higher values.
+priority: 100
+
+# The name of the job script that is generated.  This will also be the default
+# name of the job submitted to the scheduler.
+script_template: simple.sh
+
+# Used to control some aspects of how a template is rendered into a job
+# script.  The Flight Job Webapp also uses these to control some visual
+# identifiers.
+#
+# If the template is for an interactive job it should set the tags:
+# `script:type=interactive` and `session:type=desktop`.
+#
+# If the template is for an array batch job it should set the tags:
+# `script:type=batch` and `script:workload=array`.
+#
+# If the template is for a non-array batch job it should set the tags:
+# `script:type=batch`.
+tags:
+  - script:type=batch
+
+generation_questions: ...
+```
+
+#### Template questions
+
+A template also contains a number of questions that are asked when a job
+script is generated from it.  The questions are listed in `metadata.yaml`
+under the key `generation_questions`.  The questions will be asked in the
+order that they are listed in the `metadata.yaml` file.
+
+The basic format for questions is:
+
+```yaml
+generation_questions:
+    # A unique identifier for the question.
+  - id: ""
+
+    # A brief one-line description of what is being asked.
+    text: ""
+
+    # A more detailed description of what is being asked, possibly spanning
+    # multile lines.
+    description: >
+
+    # The default value, if any.  Currently, the default value must be either
+    # a string or an array of strings.
+    default: ""
+
+    # A description of how to format the question when presenting it to the
+    # user.
+    format:
+      type: ""
+
+    # The `ask_when` key is optional and indicates that this question is
+    # conditionally asked.
+    ask_when:
+      value: question.<question id>.answer
+      eq: ""
+
+```
+
+The `id`, `text`, `description` and `default` are all self-explanatory.  The
+`format` and `ask_when` keys deserve more explanation.
+
+The value of the `format` key is an object with a `type` attribute.
+Currently, the valid values for `type` are `text`, `select` and `multiselect`.
+
+If `type` is either `select` or `multiselect` an `options` key must also be
+given.  The value for `options` is an array of objects with `text` and `value`
+keys.
+
+The `ask_when` key is optional and is used to indicate that asking the
+question is conditional.  The question will be asked if the answer to the
+question referred to by `value` is equal to the value of the `eq` key.
+Currently, the only type of value that can be queried is the answer to a
+question and the only comparison is equality.  The example below will help to
+clarify this.
+
+Some complete question examples are given below:
+
+---
+
+A question asking for the job's working directory.  It accepts a single line
+of text as its answer.
+
+```yaml
+generation_questions:
+  - id: input_filename
+    text: "Input filename (including .txt extension):"
+    description: >
+      The name of the input file to use.
+
+      This should be the name of the file not the path to the file.  The file
+      must be found in your home directory.
+    default: 'data.txt'
+    format:
+      type: text
+```
+
+---
+
+A question asking for the job type.  It allows the user to select one option
+from a multiple of choices.
+
+```yaml
+  - id: job_type
+    text: "Job type:"
+    description: >
+      The job type.
+    default: 'lines'
+
+    # Here `type: select` specifies to format the question as a multiple
+    # choice.
+    format:
+      type: select
+      # The `options` key details the available options.
+      options:
+          # `text` is the value presented to the user.
+        - text: 'Lines'
+          # `value` is the value used if this option is selected.
+          value: 'lines'
+
+        - text: 'Words'
+          value: 'words'
+```
+
+Alternatively, the `type` `multiselect` can be used to allow the user to
+select multiple options.  In this case the `default`, if given, must be an
+array.
+
+---
+
+A question that is conditionally asked depending on the answer to a previous
+question.  In this case it is only asked if the answer to the `job_type`
+question was `solve`.  Currently, only answers to questions can be queried and
+the only comparison is equality.
+
+```yaml
+  - id: await_job
+    text: "ID of job to wait for before starting:"
+    description: >
+      Wait for job ID.
+    format:
+      type: text
+      minimum: 1
+
+    # The `ask_when` key indicates that this question is conditionally asked.
+    # In this case, it will be asked when the answer to the question
+    # `job_type` equals 'lines'.
+    ask_when:
+      value: question.job_type.answer
+      eq: 'lines'
+
+```
+
+### `directives.<scheduler>.erb`
+
+The `directives.<scheduler>.erb` file is an ERb template.  When it is rendered
+the questions and their answers will be available.  It is expected to render
+to a set of scheduler directives suitable for inclusion in a job script
+submitted to `<scheduler>`.  It will be used as the initial section of the
+generated job script.
+
+The questions and the answers to them are made available under the following
+keys.
+
+* `questions.<question id>.answer`: evaluates to the answer provided to the
+  question with `id` `<question id>`.
+* `questions.<question id>.default`: evaluates to the default answer specified
+  for the question with `id` `<question id>`.
+
+An example directives file is given below for the Slurm scheduler.  It
+demonstrates a number of things:
+
+1. Dynamic directives can be created that are not dependent on any questions.
+   See the working directory directive.
+2. Directives can be set involving multiple questions.  See the job name
+   directive.
+3. Further processing of the answer to question is possible.  See the job name
+   directive.
+4. Directives can be conditionally included.  See the dependencies directive.
+
+```erb
+#!/bin/bash -l
+
+#=====================
+#  Working directory
+#---------------------
+#SBATCH -D <%= File.expand_path("~") %>
+
+#============
+#  Job name
+#------------
+#SBATCH -J example-<%=
+  File.basename(questions.input_filename.answer.to_s, '.txt')
+%>-<%=
+  questions.job_type.answer.to_s
+%>
+
+#=====================
+#  Specify partition
+#---------------------
+<% if questions.job_type.answer.to_s == "lines" -%>
+#SBATCH -p lines
+<% else -%>
+#SBATCH -p default
+<% end -%>
+
+<% if questions.await_job.answer.to_s != "" -%>
+#================
+#  Dependencies
+#----------------
+# Wait for the completion of job <%= questions.await_job.answer %> prior to starting.
+#SBATCH --dependency=afterok:<%= questions.await_job.answer %>
+<% end -%>
+```
+
+### `workload.erb`
+
+The `workload.erb` file is an ERb template which will be rendered in the same
+environment as `directives.<scheduler>.erb` (see above for details on how to
+access the answers to questions).
+
+An example workload file is given below.
+
+
+```erb
+INPUT_FILE="<%= questions.input_filename.answer %>"
+WC_OPTIONS="<%= questions.job_type.answer == 'lines' ? '-l' : '-w' %>"
+
+echo "There are..."
+wc ${WC_OPTIONS} "${INPUT_FILE}" | cut -f 1 -d ' '
+echo "<%= questions.job_type.answer %> in ${INPUT_FILE}."
+```
+
+## Resultant job script
+
+To complete the example, if a template with the above questions,
+`directives.slurm.erb` and `workload.erb` were to be rendered with the
+following answers for the user `flight`.
+
+* `input_filename` = `lorem.txt`.
+* `job_type` = `words`.
+
+The resultant job script would be
+
+```sh
+#!/bin/bash -l
+
+#=====================
+#  Working directory
+#---------------------
+#SBATCH -D /home/flight
+
+#============
+#  Job name
+#------------
+#SBATCH -J example-lorem-lines
+
+#=====================
+#  Specify partition
+#---------------------
+#SBATCH -p lines
+
+
+INPUT_FILE="lorem.txt"
+WC_OPTIONS="-w"
+
+echo "There are..."
+wc ${WC_OPTIONS} "${INPUT_FILE}" | cut -f 1 -d ' '
+echo "words in ${INPUT_FILE}."
+```

--- a/docs/environment-modes.md
+++ b/docs/environment-modes.md
@@ -1,0 +1,56 @@
+## Environment Modes
+
+Flight Job has three supported environment modes in which it can operate:
+`production`, `standalone`, and `development`.
+
+* `production`:  Used when installed via the OpenFlight repos.
+* `standalone`:  Used for a manual installation intended for production.
+* `development`: Used for a manual installation intended for development. 
+
+
+### Production environment mode
+
+This mode is automatically selected when Flight Job is installed from the
+OpenFlight repos.  The configuration file will be loaded from
+`${flight_ROOT}/etc/job.yaml`.  Any relative paths in the configuration file
+are expanded from `${flight_ROOT}`.
+
+
+### Standalone environment mode
+
+This mode is to be used for a manual installation intended for production
+usage.  The configuration file is loaded from a path relative to the Flight
+Job installation directory.  Any relative paths in the configuration file are
+expanded from the Flight Job installation directory.
+
+For example, if the git repo was cloned to, say, `/opt/flight-job`, the
+configuration file would be loaded from `/opt/flight-job/etc/job.yaml` and,
+the relative path for the `templates_dir` (`usr/share/job/templates`) would be
+expanded to `/opt/flight-job/usr/share/job/templates`.
+
+There are two mechanisms by which standalone mode can be activated, either
+of which is sufficient.
+
+* Create the file `.env.development.local` containing the line
+  `flight_ENVIRONMENT=standalone`.
+  ```
+  echo flight_ENVIRONMENT=standalone > .env.development.local
+  ```
+* Export the environment variable `flight_ENVIRONMENT` set to `standalone`.
+  ```
+  export flight_ENVIRONMENT=standalone
+  ```
+
+### Development environment mode
+
+This mode is to be used for a manual installation intended for development of
+Flight Job.  The configuration file is loaded from a path relative to the
+Flight Job installation directory.  Any relative paths in the configuration
+file are expanded from the Flight Job installation directory.
+
+So if the git repo was cloned to, say, `/opt/flight-job`, the configuration
+file would be loaded from `/opt/flight-job/etc/job.yaml` and any relative
+paths expanded from `/opt/flight-job`.  E.g., by default the templates would
+be loaded from `/opt/flight-job/usr/share/job/templates`.
+
+This is the default environment mode for a manual installation.

--- a/docs/scheduler-integration.md
+++ b/docs/scheduler-integration.md
@@ -1,0 +1,86 @@
+# Scheduler Integrations
+
+By default, Flight Job integrates with the Slurm HPC scheduler.  It is
+possible to configure Flight job to integrate with another scheduler.  To do
+so involves three changes:
+
+1. Write custom integration points for the scheduler.
+2. Update any templates to generate appropriate directives for the new
+   scheduler.
+3. Configure Flight Job to use the new scheduler.
+
+## Integration scripts
+
+Flight Job uses two scripts to communicate with the scheduler and two other
+files to map from scheduler-specific language to Flight Job specific language.
+
+The following scripts need to be written:
+
+* `submit.sh`: submits a job script to the scheduler and returns information
+  about the submission and the scheduler job.
+* `monitor.sh`: communicates with the scheduler to return details about any
+  active jobs.
+
+There are two other files that need to be created:
+
+* A map from scheduler state names to Flight Job state names.
+* An ERb template used to provide an integration point for generated job
+  scripts, Flight Job and the scheduler.
+
+The configuration section below details how to configure Flight Job to use the
+new files.
+
+### `submit.sh`
+
+The `submit.sh` script receives a single argument: the path to the job script
+to be submitted.  It should submit the job script to the scheduler and return
+details about the submission and job in a Flight Job specific format.
+
+The details are to be returned as a single line of JSON sent as the final line
+of STDOUT.  The format for the [submission script
+response](/lib/flight_job/models/job/submit_response_schema.yaml) is defined
+using [JSON
+Schema](https://json-schema.org/understanding-json-schema/index.html).
+
+### `monitor.sh`
+
+The `monitor.sh` script receives a single argument: the scheduler generated ID
+of the job to be monitored.  It determines the current state of the scheduler
+job and returns details in a Flight Job specific format.
+
+The details are to be returned as a single line of JSON sent as the final line
+of STDOUT.  The format for the [monitor script
+response](/lib/flight_job/models/job/monitor_response_schema.yaml) is defined
+using JSON Schema.
+
+### State map
+
+The [Slurm state map](/etc/job/state-maps/slurm.yaml) should prove to be
+sufficient documentation to create a map for another scheduler.
+
+### Adapter
+
+The adapter Erb file maps certain scheduler-specific language to generic
+Flight Job language.  The [Slurm adapter
+file](/usr/share/job/adapter.slurm.erb) should be sufficient to create an
+adapter for another scheduler.  Of note is the mechanism used to create the
+`RESULTS_DIR` variable from Slurm specific variables.
+
+## Template directives
+
+Each template has a `directive.<scheduler>.erb` file which creates directives
+suitable for `<scheduler>` from the answers to the templates questions.
+
+A new directive file will need to be created for each template.  The [custom
+templates](/docs/custom-templates.md) documentation and the [example
+templates](/usr/share/job/templates/) might prove useful in doing so.
+
+## Configuration
+
+To configure Flight Job to use an alternative scheduler, edit the
+configuration file and change the value for `scheduler`.
+
+The default values for `submit_script_path`, `monitor_script_path`,
+`adapter_script_path` and `state_map_path` all depend on the value of
+`scheduler.  You may need to change these to match the paths of your
+integration scripts.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,31 @@
+# Versioning
+
+## CLI
+
+This application uses [semver](https://semver.org/) to version the command
+line interface. The current version is given within
+[version.rb](/lib/flight_job/version.rb) or by running `bin/job --version`.
+
+The current version covers changes to the public command line interface.
+
+The following changes to the CLI are considered breaking changes and will only
+be done as part of a major version release.
+
+* Removing a command or alias.
+* Removing a positional argument to a command.
+* Changing the order of positional arguments to a command.
+* Removing an option to a command.
+* Changing the column order of the machine readable\* `list*` and `info*`
+  outputs.
+* Removing keys from the `--json` output.
+* Renaming keys in the `--json` output.
+
+The following changes to the CLI are not considered breaking changes.  They
+may be done in a minor release.
+
+* Adding a command or alias.
+* Adding a positional argument to a command provided it does not break usage
+  of that command without the new position argument.
+* Adding an option to a command.
+* Adding new columns to the machine readable\* `list*` and `info*` outputs.
+* Adding keys to the `--json` output.

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -88,31 +88,12 @@ module FlightJob
       }
     })
 
-    SUBMIT_RESPONSE_SCHEMA = JSONSchemer.schema({
-      "type" => "object",
-      "additionalProperties" => false,
-      "required" => ["id", "results_dir"],
-      "properties" => {
-        "id" => { "type" => "string" },
-        "stdout" => { "type" => ["string", "null"] },
-        "stderr" => { "type" => ["string", "null"] },
-        "results_dir" => { "type" => "string" },
-      }
-    })
-
-    MONITOR_RESPONSE_SCHEMA = JSONSchemer.schema({
-      "type" => "object",
-      "additionalProperties" => false,
-      "required" => ["state"],
-      "properties" => {
-        "state" => { "type" => "string" },
-        "reason" => { "type" => ["string", "null"] },
-        "start_time" => { "type" => ["string", "null"] },
-        "end_time" => { "type" => ["string", "null"] },
-        "estimated_start_time" => { "type" => ["string", "null"] },
-        "estimated_end_time" => { "type" => ["string", "null"] }
-      }
-    })
+    SUBMIT_RESPONSE_SCHEMA = JSONSchemer.schema(
+      YAML.load_file(File.join(__dir__, 'job/submit_response_schema.yaml'))
+    )
+    MONITOR_RESPONSE_SCHEMA = JSONSchemer.schema(
+      YAML.load_file(File.join(__dir__, 'job/monitor_response_schema.yaml'))
+    )
 
     def self.load_all
       Dir.glob(new(id: '*').metadata_path).map do |path|

--- a/lib/flight_job/models/job/monitor_response_schema.yaml
+++ b/lib/flight_job/models/job/monitor_response_schema.yaml
@@ -1,0 +1,47 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+# NOTE: This document contains the response specification for the
+#       "monitor script".
+#
+#       It uses JSON:Schema as its validation library:
+#       https://json-schema.org/understanding-json-schema/index.html
+#
+#       YAML is used to purely to support comments and syntax highlighting
+#==============================================================================
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["state"],
+  "properties": {
+    "state": { "type": "string" },
+    "reason": { "type": ["string", "null"] },
+    "start_time": { "type": ["string", "null"] },
+    "end_time": { "type": ["string", "null"] },
+    "estimated_start_time": { "type": ["string", "null"] },
+    "estimated_end_time": { "type": ["string", "null"] }
+  }
+}

--- a/lib/flight_job/models/job/monitor_response_schema.yaml
+++ b/lib/flight_job/models/job/monitor_response_schema.yaml
@@ -33,15 +33,13 @@
 #
 # YAML is used to purely to support comments and syntax highlighting
 #==============================================================================
-# NOTE: Updates on Minor Releases
+# NOTE: Independent Versioning
 #
 # The 'monitor.sh` provides core functionality that flight-job relies on to
 # operate correctly. This functionality will change over time as part of minor
 # release.
 #
-# The scripts that are distributed with this repository will be updated
-# to match this specification. Custom scripts may need to be upgraded on
-# minor releases.
+# For this reason, the specification is versioned independently to the CLI.
 #==============================================================================
 # CHANGELOG:
 # * 2.3.0 - Extracted Specification
@@ -57,6 +55,8 @@
   "additionalProperties": false,
   "required": ["state"],
   "properties": {
+    # NOTE: version will be required in future specifications
+    "version": { "enum": [0] },
     "state": { "type": "string" },
     "reason": { "type": ["string", "null"] },
     "start_time": { "type": ["string", "null"] },

--- a/lib/flight_job/models/job/monitor_response_schema.yaml
+++ b/lib/flight_job/models/job/monitor_response_schema.yaml
@@ -24,13 +24,33 @@
 # For more information on Flight Job, please visit:
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
-# NOTE: This document contains the response specification for the
-#       "monitor script".
+# NOTE: JSON Schema
 #
-#       It uses JSON:Schema as its validation library:
-#       https://json-schema.org/understanding-json-schema/index.html
+# This document contains the response specification for the "monitor script".
 #
-#       YAML is used to purely to support comments and syntax highlighting
+# It uses JSON:Schema as its validation library:
+# https://json-schema.org/understanding-json-schema/index.html
+#
+# YAML is used to purely to support comments and syntax highlighting
+#==============================================================================
+# NOTE: Updates on Minor Releases
+#
+# The 'monitor.sh` provides core functionality that flight-job relies on to
+# operate correctly. This functionality will change over time as part of minor
+# release.
+#
+# The scripts that are distributed with this repository will be updated
+# to match this specification. Custom scripts may need to be upgraded on
+# minor releases.
+#==============================================================================
+# CHANGELOG:
+# * 2.3.0 - Extracted Specification
+#==============================================================================
+# ARGV:
+#
+# The argument vector to the 'monitor.sh' is as follows:
+#
+# 1. The scheduler generated ID for the job.
 #==============================================================================
 {
   "type": "object",

--- a/lib/flight_job/models/job/monitor_response_schema.yaml
+++ b/lib/flight_job/models/job/monitor_response_schema.yaml
@@ -31,7 +31,8 @@
 # It uses JSON:Schema as its validation library:
 # https://json-schema.org/understanding-json-schema/index.html
 #
-# YAML is used to purely to support comments and syntax highlighting
+# This document uses YAML to support syntax highlighting and comments;
+# otherwise it is regular JSON.
 #==============================================================================
 # NOTE: Independent Versioning
 #

--- a/lib/flight_job/models/job/submit_response_schema.yaml
+++ b/lib/flight_job/models/job/submit_response_schema.yaml
@@ -1,0 +1,45 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+# NOTE: This document contains the response specification for the
+#       "submit script".
+#
+#       It uses JSON:Schema as its validation library:
+#       https://json-schema.org/understanding-json-schema/index.html
+#
+#       YAML is used to purely to support comments and syntax highlighting
+#==============================================================================
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "results_dir"],
+  "properties": {
+    "id": { "type": "string" },
+    "stdout": { "type": "string" },
+    "stderr": { "type": "string" },
+    "results_dir": { "type": "string" }
+  }
+}

--- a/lib/flight_job/models/job/submit_response_schema.yaml
+++ b/lib/flight_job/models/job/submit_response_schema.yaml
@@ -24,13 +24,33 @@
 # For more information on Flight Job, please visit:
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
-# NOTE: This document contains the response specification for the
-#       "submit script".
+# NOTE: JSON Schema
 #
-#       It uses JSON:Schema as its validation library:
-#       https://json-schema.org/understanding-json-schema/index.html
+# This document contains the response specification for the "submit script".
 #
-#       YAML is used to purely to support comments and syntax highlighting
+# It uses JSON:Schema as its validation library:
+# https://json-schema.org/understanding-json-schema/index.html
+#
+# YAML is used to purely to support comments and syntax highlighting
+#==============================================================================
+# NOTE: Updates on Minor Releases
+#
+# The 'submit.sh` provides core functionality that flight-job relies on to
+# operate correctly. This functionality will change over time as part of minor
+# release.
+#
+# The scripts that are distributed with this repository will be updated
+# to match this specification. Custom scripts may need to be upgraded on
+# minor releases.
+#==============================================================================
+# CHANGELOG:
+# * 2.3.0 - Extracted Specification
+#==============================================================================
+# ARGV:
+#
+# The argument vector to the 'submit.sh' is as follows:
+#
+# 1. The absolute path to the render script
 #==============================================================================
 {
   "type": "object",

--- a/lib/flight_job/models/job/submit_response_schema.yaml
+++ b/lib/flight_job/models/job/submit_response_schema.yaml
@@ -33,15 +33,13 @@
 #
 # YAML is used to purely to support comments and syntax highlighting
 #==============================================================================
-# NOTE: Updates on Minor Releases
+# NOTE: Independent Versioning
 #
 # The 'submit.sh` provides core functionality that flight-job relies on to
 # operate correctly. This functionality will change over time as part of minor
 # release.
 #
-# The scripts that are distributed with this repository will be updated
-# to match this specification. Custom scripts may need to be upgraded on
-# minor releases.
+# For this reason, the specification is version independently to the CLI.
 #==============================================================================
 # CHANGELOG:
 # * 2.3.0 - Extracted Specification
@@ -57,6 +55,8 @@
   "additionalProperties": false,
   "required": ["id", "results_dir"],
   "properties": {
+    # NOTE: version will be required in future specifications
+    "version": { "enum": [0] },
     "id": { "type": "string" },
     "stdout": { "type": "string" },
     "stderr": { "type": "string" },

--- a/lib/flight_job/models/job/submit_response_schema.yaml
+++ b/lib/flight_job/models/job/submit_response_schema.yaml
@@ -31,7 +31,8 @@
 # It uses JSON:Schema as its validation library:
 # https://json-schema.org/understanding-json-schema/index.html
 #
-# YAML is used to purely to support comments and syntax highlighting
+# This document uses YAML to support syntax highlighting and comments;
+# otherwise it is regular JSON.
 #==============================================================================
 # NOTE: Independent Versioning
 #

--- a/lib/flight_job/version.rb
+++ b/lib/flight_job/version.rb
@@ -25,5 +25,5 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 module FlightJob
-  VERSION = '2.4.0'
+  VERSION = '2.5.0-alpha'
 end

--- a/libexec/job/slurm/monitor.sh
+++ b/libexec/job/slurm/monitor.sh
@@ -43,6 +43,7 @@ set +e
 #       flight-job will set the times according to the state
 read -r -d '' template <<'TEMPLATE' || true
 {
+  version: 0,
   state: ($state),
   reason: ($reason),
   start_time: ($start_time),

--- a/libexec/job/slurm/submit.sh
+++ b/libexec/job/slurm/submit.sh
@@ -43,6 +43,7 @@ which "jq" >/dev/null
 # Specify the template for the JSON response
 read -r -d '' template <<'TEMPLATE' || true
 {
+  version: 0,
   id: ($id),
   stdout: ($stdout),
   stderr: ($stderr),


### PR DESCRIPTION
This PR does two things:

* Standardise the `config` so it matches the `builder`, and
* Document the installation/configuration in the README.

---

The standardised config work is broadly the same as #27 is need to make supporting multiple schedulers easier. It also means the documentation applies to the `production` rpm build as well as a "standalone" usage.

It does mean a standalone install can not be seamlessly upgraded from and older version to the current one. This will *hopefully* be a one time annoyance. All future releases should have parity between the `builder` and standalone configs.

---

The documentation introduces the concept of a `standalone` environment. This has not been QA and is still at the "proof of concept" stage. However the existing configuration mechanism already implicitly supports environments other than `production`/`standalone`, this PR formalises the usage.

Broadly there are three environments:
* `production` - Respects `flight_ROOT` and uses the production gems,
* `standalone` - Ignores `flight_ROOT` but still uses the production gems, and
* `development` - Ignores `flight_ROOT` and uses the development gems.

By using a `standalone` environment, it makes the usage of `flight_ROOT` clearer.

Currently `production` will default to `standalone` behaviour if `flight_ROOT` is not set. Should this be changed to raising an error instead?