### PR TITLE
Warn if re-ask selected questions is empty

### DIFF
--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -199,6 +199,7 @@ module FlightJob
         def prompt_again
           opts = {
             default: if @prompt_for_selected
+                       @prompt_for_selected = false
                        3
                      elsif @prompt_for_name
                        1
@@ -242,7 +243,6 @@ module FlightJob
                 Press any key to continue...
               WARN
             else
-              @prompt_for_selected = false
               prompt_questions(*selected)
             end
             true

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -235,7 +235,7 @@ module FlightJob
             end
             if selected.empty?
               @prompt_for_selected = true
-              prompt.keypress pastel.yellow(<<~WARN)
+              prompt.keypress(pastel.yellow(<<~WARN.chomp))
 
                 You have not selected any questions to be re-ask!
                 Questions need to be explicitly selected with Space.

--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -113,13 +113,15 @@ module FlightJob
             text = summary.sub(/\n+\Z/, '')
             diff = TTY::Screen.rows - text.lines.count
             # Work around issues with LESS -SFRX flag
-            # The -F/--quit-if-one-screen flag disables less if the summary fits on one page
-            # However, the prompt_again question adds an additional X lines, which isn't being
-            # accounted for.
+            # The -F/--quit-if-one-screen flag disables less if the summary
+            # fits on one page
             #
-            # The 'pager' should still be used, as the user may have changed either PAGER/LESS
-            # env vars. Instead the text is padded with newlines, if its length is X lines less
-            # than the terminal height
+            # However, the prompt_again question adds an additional X lines,
+            # which isn't being accounted for.
+            #
+            # The 'pager' should still be used, as the user may have changed
+            # either PAGER/LESS env vars. Instead the text is padded with
+            # newlines, if its length is X lines less than the terminal height
             if 0 < diff && diff < 7
               text = "#{text}#{"\n" * diff}"
             end
@@ -196,7 +198,9 @@ module FlightJob
         # return [Boolean] if the user requested questions to be re-asked
         def prompt_again
           opts = {
-            default: if @prompt_for_name
+            default: if @prompt_for_selected
+                       3
+                     elsif @prompt_for_name
                        1
                      elsif @prompt_for_notes
                        2
@@ -221,13 +225,26 @@ module FlightJob
               The exact question prompts may differ if the dependencies change.
             WARN
             opts = { show_help: :always, echo: false, help: MULTI_HELP }
-            selected = prompt.multi_select("Which questions would you like to change?", **opts) do |menu|
+            text = "Which questions would you like to change?"
+            selected = prompt.multi_select(text, **opts) do |menu|
               questions.each do |question|
                 next unless prompt?(question)
                 menu.choice question.text, question
               end
             end
-            prompt_questions(*selected) unless selected.empty?
+            if selected.empty?
+              @prompt_for_selected = true
+              prompt.keypress pastel.yellow(<<~WARN)
+
+                You have not selected any questions to be re-ask!
+                Questions need to be explicitly selected with Space.
+
+                Press any key to continue...
+              WARN
+            else
+              @prompt_for_selected = false
+              prompt_questions(*selected)
+            end
             true
           when :name
             prompt_name


### PR DESCRIPTION
It is fairly easy for a user to exit out of the "re-ask selected questions" prompt without selecting any questions. This needs to be _allowed_ otherwise there wouldn't be an easy way to exit the prompt. 

Instead a warning prompt is issued before the user is redirected to the main REPL. This warning tells the user they need to select questions with `Space`. The main REPL defaults to the "re-ask selected questions" prompt.