### PR TITLE
Replace the --include flag with flight_JOB_includes env var

### DIFF
--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -139,6 +139,16 @@
 # submission_period: 3600
 
 # ==============================================================================
+# Include Related Resources
+# Specify the related resource that should be included in the JSON output. The
+# resources should be specified as CSV. This feature *may* be removed within a
+# minor release, proceed with caution.
+#
+# The environment variable flight_JOB_include takes precedence.
+# ==============================================================================
+# includes: ''
+
+# ==============================================================================
 # Log Path
 # The file the logger will write to. It will write to standard error if
 # omitted.

--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -139,16 +139,6 @@
 # submission_period: 3600
 
 # ==============================================================================
-# Include Related Resources
-# Specify the related resource that should be included in the JSON output. The
-# resources should be specified as CSV. This feature *may* be removed within a
-# minor release, proceed with caution.
-#
-# The environment variable flight_JOB_include takes precedence.
-# ==============================================================================
-# includes: ''
-
-# ==============================================================================
 # Log Path
 # The file the logger will write to. It will write to standard error if
 # omitted.

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -74,8 +74,6 @@ module FlightJob
     global_slop.bool '--pretty', 'Display a human friendly output, when supported'
     global_slop.bool '--ascii', 'Display a simplified version of the output, when supported'
     global_slop.bool '--json', 'Display a JSON version of the output, when supported'
-    global_slop.array '--include', 'Include the specified related resources in the JSON output',
-                      delimiter: ','
 
     create_command 'list-templates' do |c|
       c.summary = 'List available templates'

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -111,7 +111,7 @@ module FlightJob
 
     def render_output(klass, data)
       if opts.json
-        json = data.as_json(include: opts.include)
+        json = data.as_json
         output_options[:interactive] ? JSON.pretty_generate(json) : JSON.dump(json)
       else
         klass.build_output(**output_options).render(*data)

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -68,6 +68,8 @@ module FlightJob
     attribute :max_stdin_size, default: 1048576
     validates :max_stdin_size, numericality: { only_integers: true }
 
+    attribute :includes, default: '', transform: ->(v) { v.to_s.split(',') }
+
     attribute :log_path, required: false,
               default: '~/.cache/flight/log/share/job.log',
               transform: ->(path) do

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -365,7 +365,7 @@ module FlightJob
         hash["stdout_size"] = File.size(stdout_path) if stdout_readable?
         hash["stderr_size"] = File.size(stderr_path) if stderr_readable?
 
-        if opts.fetch(:include, []).include? 'script'
+        if Flight.config.includes.include? 'script'
           hash['script'] = load_script
         end
 

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -297,10 +297,10 @@ module FlightJob
         "path" => script_path,
         "tags" => tags,
       }.merge(metadata).tap do |hash|
-        if opts.fetch(:include, []).include? 'template'
+        if Flight.config.includes.include? 'template'
           hash['template'] = load_template
         end
-        if opts.fetch(:include, []).include? 'jobs'
+        if Flight.config.includes.include? 'jobs'
           # NOTE: Consider using a file registry instead
           hash['jobs'] = Job.load_all.select { |s| s.script_id == id }
         end

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -225,7 +225,7 @@ module FlightJob
         'id' => id,
         'path' => template_path,
       }.merge(metadata).tap do |hash|
-        if opts.fetch(:include, []).include? 'scripts'
+        if Flight.config.includes.include? 'scripts'
           # NOTE: Consider using a file registry instead
           hash['scripts'] = Script.load_all.select { |s| s.template_id == id }
         end


### PR DESCRIPTION
The `--include` feature is only required by the API and shouldn't be part of the CLI's public interface.

Instead, it has been replaced with a `flight_JOB_includes` config/env var. This config has been documented as volatile and subject to change. This is to allow time for its future to become clear. 