### PR TITLE
Do not force array jobs to report an incorrect stdout/stderr

### DIFF
--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -75,6 +75,10 @@ module FlightJob
     global_slop.bool '--ascii', 'Display a simplified version of the output, when supported'
     global_slop.bool '--json', 'Display a JSON version of the output, when supported'
 
+    # NOTE: NEXT MAJOR CLI RELEASE
+    # Please review the Outputs and <Model>#serializable_hash methods on the next major release
+    # These will need simplifying
+
     create_command 'list-templates' do |c|
       c.summary = 'List available templates'
     end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -301,10 +301,6 @@ module FlightJob
       stdout_path == stderr_path
     end
 
-    # NOTE: NEXT MAJOR CLI RELEASE
-    # * stdout/stderr - Should become optional as array jobs don't really have a "single"
-    #                   out/err file. Currently they get set to /dev/null as a stop gap.
-    #                   More accurately it should be null.
     def serializable_hash(opts = nil)
       opts ||= {}
       {
@@ -394,8 +390,8 @@ module FlightJob
         # Parse stdout on successful commands
         process_output('submit', status, out) do |data|
           self.scheduler_id = data['id']
-          self.stdout_path = data['stdout'].blank? ? "/dev/null" : data['stdout']
-          self.stderr_path = data['stderr'].blank? ? "/dev/null" : data['stderr']
+          self.stdout_path = data['stdout'].blank? ? nil : data['stdout']
+          self.stderr_path = data['stderr'].blank? ? nil : data['stderr']
           self.results_dir = data['results_dir']
         end
 

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -91,11 +91,11 @@ module FlightJob
     SUBMIT_RESPONSE_SCHEMA = JSONSchemer.schema({
       "type" => "object",
       "additionalProperties" => false,
-      "required" => ["id", "stdout", "stderr", "results_dir"],
+      "required" => ["id", "results_dir"],
       "properties" => {
         "id" => { "type" => "string" },
-        "stdout" => { "type" => "string" },
-        "stderr" => { "type" => "string" },
+        "stdout" => { "type" => ["string", "null"] },
+        "stderr" => { "type" => ["string", "null"] },
         "results_dir" => { "type" => "string" },
       }
     })
@@ -301,6 +301,10 @@ module FlightJob
       stdout_path == stderr_path
     end
 
+    # NOTE: NEXT MAJOR CLI RELEASE
+    # * stdout/stderr - Should become optional as array jobs don't really have a "single"
+    #                   out/err file. Currently they get set to /dev/null as a stop gap.
+    #                   More accurately it should be null.
     def serializable_hash(opts = nil)
       opts ||= {}
       {
@@ -390,8 +394,8 @@ module FlightJob
         # Parse stdout on successful commands
         process_output('submit', status, out) do |data|
           self.scheduler_id = data['id']
-          self.stdout_path = data['stdout']
-          self.stderr_path = data['stderr']
+          self.stdout_path = data['stdout'].blank? ? "/dev/null" : data['stdout']
+          self.stderr_path = data['stderr'].blank? ? "/dev/null" : data['stderr']
           self.results_dir = data['results_dir']
         end
 

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -81,11 +81,11 @@ module FlightJob
       # Skip this validation on :id_check
       next if validation_context == :id_check
 
-      unless (errors = SCHEMA.validate(metadata).to_a).empty?
+      unless (schema_errors = SCHEMA.validate(metadata).to_a).empty?
         errors.add(:metadata, 'is not valid')
         path_tag = File.exists?(metadata_path) ? metadata_path : id
         FlightJob.logger.debug("Invalid metadata: #{path_tag}\n") do
-          JSON.pretty_generate(errors)
+          JSON.pretty_generate(schema_errors)
         end
       end
     end

--- a/libexec/job/slurm/submit.sh
+++ b/libexec/job/slurm/submit.sh
@@ -79,9 +79,12 @@ if [[ $exit_status -ne 0 ]]; then
   exit $exit_status
 fi
 
-# Extract the sdout/stderr paths
-stdout=$(echo "$control" | grep '^StdOut=' | cut -d= -f2)
-stderr=$(echo "$control" | grep '^StdErr=' | cut -d= -f2)
+# Skip the stdout/stderr for the "main" array job
+if [ -z "$(echo "$control" | grep "ArrayJobId")" ]; then
+  # Extract the sdout/stderr paths (most jobs)
+  stdout=$(echo "$control" | grep '^StdOut=' | cut -d= -f2)
+  stderr=$(echo "$control" | grep '^StdErr=' | cut -d= -f2)
+fi
 
 # Determine the results directory
 working=$(echo "$control" | grep '^WorkDir=' | cut -d= -f2)


### PR DESCRIPTION
Previously all `job` submissions had to report back a `stdout`/`stderr`. Technically it could have been empty string, but this is more an oversight then part of the specification.

This causes issues with array jobs for a few reasons:
* `scontrol` reports the wrong paths for the main "job",
* The "main" job does not really have a `stdout`/`stderr` path,
* The paths for each "array task" does not become available until the individual job starts, and
* The current specification only supports a single set of paths.

---

As a stopgap measure, the `stdout`/`stderr` inputs are now optional on `submit.sh`. They will default to `/dev/null` if they are omitted. Ideally they would allow to be `nil`/`null`, however this is not currently possible. Both fields are part of the CLI public interface as a required key via the `--json` flag.

This means `array` jobs aren't flat out wrong when reporting back the paths. The next PR will allow them to update the `stdout`/`stderr` files on `monitor.sh`