### PR TITLE
Update submit.sh and add monitor-array.sh

### DIFF
--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -86,18 +86,21 @@
 # submit_script_path: libexec/job/<scheduler>/submit.sh
 
 # ==============================================================================
-# Monitor Script Path
-# Specify the path to the script which monitors jobs.
+# Monitor Script Paths
+# Specify the paths to the scripts which monitor jobs.  Separate scripts are
+# used for monitoring array and non-array jobs.
 #
-# The default value will automatically use the 'scheduler' config. This feature
+# The default values will automatically use the 'scheduler' config. This feature
 # is not supported when overridden.
 #
 # Relative paths are expanded according to the "Relative path expansion" rules
 # described below.
 #
-# The environment variable flight_JOB_monitor_script_path takes precedence.
+# The environment variables flight_JOB_monitor_script_path and
+# flight_JOB_monitor_array_script_path take precedence.
 # ==============================================================================
 # monitor_script_path: libexec/job/<scheduler>/monitor.sh
+# monitor_array_script_path: libexec/job/<scheduler>/monitor-array.sh
 
 # ==============================================================================
 # Script Adapter Path

--- a/lib/flight_job/commands/view_job_output.rb
+++ b/lib/flight_job/commands/view_job_output.rb
@@ -29,28 +29,34 @@ module FlightJob
   module Commands
     class ViewJobOutput < Command
       def run
-        assert_command_type_valid
-        assert_file_path
+        @job = load_job(args.first)
+
+        assert_output_type_valid
+        assert_stderr_not_merged if viewing_stderr?
+        assert_file_exists
+
         pager.page(File.read(file_path))
       end
 
       private
 
-      def assert_command_type_valid
+      def assert_output_type_valid
         return if [:stdout, :stderr].include?(opts.type)
         raise InternalError, "Invalid output type #{opts.type.inspect}"
       end
 
-      def assert_file_path
-        if opts.type == :stderr && job.stderr_merged?
+      def assert_stderr_not_merged
+        if @job.stderr_merged?
           prog_name = ENV.fetch('FLIGHT_PROGRAM_NAME') { 'bin/job' }
           raise MissingError, <<~ERROR.chomp
             Cannot display the job's standard error as it has been merged with standard out.
             Please run the following instead:
-            #{pastel.yellow "#{prog_name} view-job-stdout #{job.id}"}
+            #{pastel.yellow "#{prog_name} view-job-stdout #{@job.id}"}
           ERROR
         end
+      end
 
+      def assert_file_exists
         unless File.exists?(file_path)
           raise MissingError, "The job's standard " \
             "#{opts.type == :stdout ? 'output' : 'error'} file does not exists: "\
@@ -59,15 +65,15 @@ module FlightJob
       end
 
       def file_path
-        if opts.type == :stdout
-          job.stdout_path
+        if viewing_stderr?
+          @job.stderr_path!
         else
-          job.stderr_path
+          @job.stdout_path!
         end
       end
 
-      def job
-        @job ||= load_job(args.first)
+      def viewing_stderr?
+        opts.type == :stderr
       end
     end
   end

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -74,6 +74,11 @@ module FlightJob
               transform: relative_to(root_path)
     validates :monitor_script_path, presence: true
 
+    attribute :monitor_array_script_path,
+              default: ->(config) { File.join('libexec/job', config.scheduler, 'monitor-array.sh') },
+              transform: relative_to(root_path)
+    validates :monitor_array_script_path, presence: true
+
     attribute :adapter_script_path,
               default: ->(config) { File.join("usr/share/job/adapter.#{config.scheduler}.erb") },
               transform: relative_to(root_path)

--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -45,9 +45,9 @@ module FlightJob
         end
       end
 
-      delegate :id, to: :object
+      delegate :id, :state, to: :object
       delegate_metadata :script_id, :start_time, :end_time, :scheduler_id, :scheduler_state,
-        :stdout_path, :stderr_path, :results_dir, :reason, :created_at, :state,
+        :stdout_path, :stderr_path, :results_dir, :reason, :created_at,
         :submit_status, :submit_stdout, :submit_stderr, :estimated_start_time, :estimated_end_time
 
       def actual_start_time

--- a/lib/flight_job/errors.rb
+++ b/lib/flight_job/errors.rb
@@ -46,7 +46,10 @@ module FlightJob
 
   InternalError = Error.define_class(1)
   GeneralError = Error.define_class(2)
+
   InputError = GeneralError.define_class(3)
+  class InvalidOperation < InputError; end
+
   CommandError = GeneralError.define_class(6)
   DuplicateError = GeneralError.define_class(7)
 

--- a/lib/flight_job/job_transitions/failed_submission_transition.rb
+++ b/lib/flight_job/job_transitions/failed_submission_transition.rb
@@ -34,7 +34,7 @@ module FlightJob
         now = Time.now.to_i
         if now - start > FlightJob.config.submission_period
           FlightJob.logger.error <<~ERROR
-            The following job is being flaged as FAILED as it has not been submitted: #{id}
+            The following job is being flagged as FAILED as it has not been submitted: #{id}
           ERROR
           metadata['job_type'] = "FAILED_SUBMISSION"
           metadata['submit_status'] = 126

--- a/lib/flight_job/job_transitions/job_transition_helper.rb
+++ b/lib/flight_job/job_transitions/job_transition_helper.rb
@@ -85,10 +85,10 @@ module FlightJob
             .each { |k, v| object.metadata[k] = (v == "" ? nil : v) }
 
         # Apply the scheduler_state, defaulting to UNKNOWN when appropriate
-        if metadata['state'] == 'UNKNOWN' && [nil, ''].include?(opts['scheduler_state'])
-          metadata['scheduler_state'] = 'unknown'
+        if object.metadata['state'] == 'UNKNOWN' && [nil, ''].include?(opts['scheduler_state'])
+          object.metadata['scheduler_state'] = 'unknown'
         else
-          metadata['scheduler_state'] = opts['scheduler_state']
+          object.metadata['scheduler_state'] = opts['scheduler_state']
         end
 
         # Parse and apply the time based keys
@@ -103,15 +103,15 @@ module FlightJob
           next if [nil, ""].include? path
 
           # Set the path
-          if metadata[key].nil?
-            metadata[key] = path
+          if object.metadata[key].nil?
+            object.metadata[key] = path
 
           # This shouldn't happen in practice. This scheduler is assumable doing
           # something odd? Log the error and continue.
-          elsif metadata[key] != path
+          elsif object.metadata[key] != path
             FlightJob.logger.error <<~ERROR.chomp
               Attempted to modify the #{key} for #{object_tag(object)}
-              Original: #{metadata[key]}
+              Original: #{object.metadata[key]}
               Provided: #{path}
 
               The provided value has been discared!

--- a/lib/flight_job/job_transitions/monitor_array_transition.rb
+++ b/lib/flight_job/job_transitions/monitor_array_transition.rb
@@ -1,0 +1,107 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+module FlightJob
+  module JobTransitions
+    class MonitorArrayTransition < SimpleDelegator
+      include JobTransitions::JobTransitionHelper
+
+      SCHEMA = JSONSchemer.schema({
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => ["tasks", "lazy"],
+        "properties" => {
+          "version" => { "const" => 1 },
+          "lazy" => { "type" => "boolean" },
+          "tasks" => {
+            "type" => "object",
+            "additionalProperties" => false, # Redundant, probably ...
+            "patternProperties" => {
+              # Tasks are validated against the singleton jobs schemas
+              ".*" => { "type" => "object" }
+            }
+          }
+        }
+      })
+      TASK_SCHEMAS = MonitorSingletonTransition::SCHEMAS
+
+      def run
+        raise NotImplementedError
+      end
+
+      def run!
+        FlightJob.logger.info("Monitoring Job: #{id}")
+        cmd = [FlightJob.config.monitor_array_script_path, scheduler_id]
+        execute_command(*cmd, tag: 'monitor') do |status, stdout, stderr, data|
+          if status.success?
+            # Validate the output
+            validate_data(SCHEMA, data, tag: "monitor-array")
+            data['tasks'].each do |index, datum|
+              validate_data(TASK_SCHEMAS[:initial], datum, tag: "monitor-array task: #{index} (initial)")
+              state = datum['state']
+              validate_data(TASK_SCHEMAS[state], datum, tag: "monitor-array task: #{index} (#{state})")
+            end
+
+            # Create/Update Each task
+            data['tasks'].each do |index, datum|
+              process_task(index, datum)
+            end
+
+            # Update the lazy flag
+            # NOTE: This is deliberately done after the tasks have been updated
+            #
+            # It is difficult to preform a "transaction" as multiple metadata files
+            # are being updated. However it can be reasonable assumed the various
+            # updates will succeed, as the response has been validated.
+            #
+            # Updating the lazy flag at the end gives the monitor a chance to run
+            # again if an error has occurred.
+            metadata["lazy"] = data["lazy"]
+            save_metadata
+
+            # Remove the indexing file in terminal state
+            # FileUtils.rm_f active_index_path if terminal?
+          end
+        end
+      end
+
+      private
+
+      def process_task(index, data)
+      end
+
+      def parse_time(time, type:)
+        return nil if ['', nil].include?(time)
+        Time.parse(time).strftime("%Y-%m-%dT%T%:z")
+      rescue ArgumentError
+        FlightJob.logger.error "Failed to parse #{type}: #{time}"
+        FlightJob.logger.debug $!.full_message
+        raise_command_error
+      end
+    end
+  end
+end

--- a/lib/flight_job/job_transitions/submit_transition.rb
+++ b/lib/flight_job/job_transitions/submit_transition.rb
@@ -61,11 +61,10 @@ module FlightJob
         "ARRAY" => JSONSchemer.schema({
           "type" => "object",
           "additionalProperties" => false,
-          "required" => [*SHARED_KEYS, "lazy"],
+          "required" => SHARED_KEYS,
           "properties" => {
             **SHARED_PROPS,
-            "job_type" => { "const" => "ARRAY" },
-            "lazy" => { "const" => true }
+            "job_type" => { "const" => "ARRAY" }
           }
         })
       }
@@ -148,7 +147,7 @@ module FlightJob
             MonitorSingletonTransition.new(__getobj__).run!
           when 'ARRAY'
             metadata['job_type'] = 'ARRAY'
-            metadata['lazy'] = data['lazy']
+            metadata['lazy'] = true
             metadata['results_dir'] = data['results_dir']
             metadata['scheduler_id'] = data['id']
 

--- a/lib/flight_job/job_transitions/submit_transition.rb
+++ b/lib/flight_job/job_transitions/submit_transition.rb
@@ -156,7 +156,8 @@ module FlightJob
           save_metadata
 
           # Remove the indexing file if in non-terminal state
-          if terminal?
+          # TODO: Do this properly
+          if terminal? && job_type != 'ARRAY'
             FileUtils.rm_f active_index_path
           end
         end

--- a/lib/flight_job/job_transitions/submit_transition.rb
+++ b/lib/flight_job/job_transitions/submit_transition.rb
@@ -142,13 +142,18 @@ module FlightJob
           case data['job_type']
           when 'SINGLETON'
             metadata['job_type'] = 'SINGLETON'
-            metadata['state'] = 'PENDING'
+            metadata['results_dir'] = data['results_dir']
             metadata['scheduler_id'] = data['id']
+            metadata['state'] = 'PENDING'
             metadata['stdout_path'] = data['stdout']
             metadata['stderr_path'] = data['stderr']
+          when 'ARRAY'
+            metadata['job_type'] = 'ARRAY'
+            metadata['lazy'] = data['lazy']
             metadata['results_dir'] = data['results_dir']
-            save_metadata
+            metadata['scheduler_id'] = data['id']
           end
+          save_metadata
 
           # Remove the indexing file if in non-terminal state
           if terminal?

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -425,6 +425,7 @@ module FlightJob
       @controls_dir ||= ControlsDir.new(File.join(job_dir, 'controls'))
     end
 
+    # NOTE: Requires parity with task_dir
     def job_dir
       @job_dir ||= File.join(FlightJob.config.jobs_dir, id)
     end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -399,15 +399,13 @@ module FlightJob
       JobTransitions::SubmitTransition.new(self).run!
     end
 
-    # Deliberately not a case statement to allow fall through
     def monitor
-      if job_type == 'INITIALIZING'
+      case job_type
+      when 'INITIALIZING'
         JobTransitions::FailedSubmissionTransition.new(self).run
-      end
-      if job_type == 'SINGLETON'
+      when 'SINGLETON'
         JobTransitions::MonitorSingletonTransition.new(self).run!
-      end
-      if job_type == 'ARRAY'
+      when 'ARRAY'
         JobTransitions::MonitorArrayTransition.new(self).run!
       end
     end
@@ -447,7 +445,7 @@ module FlightJob
         FileUtils.mkdir_p File.dirname(metadata_path)
         File.write metadata_path, YAML.dump(metadata)
       else
-        FlightJob.logger.error("Failed to savve job metadata: #{id}")
+        FlightJob.logger.error("Failed to save job metadata: #{id}")
         FlightJob.logger.info(errors.full_messages.join("\n"))
         raise InternalError, "Unexpectedly failed to save job '#{id}' metadata"
       end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -59,7 +59,7 @@ module FlightJob
         "required" => SHARED_KEYS,
         "properties" => {
           **SHARED_PROPS,
-          "job_type" => { "enum" => ["INITIALIZING", "SINGLETON", "FAILED_SUBMISSION"] }
+          "job_type" => { "enum" => ["INITIALIZING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"] }
         }
       }),
 
@@ -98,7 +98,7 @@ module FlightJob
 
     # The following are the keys which are shared by the "submitted" job types
     SHARED_SUBMITTED_KEYS = [
-      *SHARED_KEYS, 'submit_status', 'submit_stdout', 'submit_stderr', 'scheduler_state'
+      *SHARED_KEYS, 'submit_status', 'submit_stdout', 'submit_stderr'
     ]
     SHARED_SUBMITTED_PROPS = SHARED_PROPS.merge({
       "submit_status" => { const: 0 },
@@ -138,6 +138,21 @@ module FlightJob
           "scheduler_state" => { "type" => "string", "minLength" => 1 },
         }
       }),
+
+      "ARRAY" => JSONSchemer.schema({
+        "type" => "object",
+        "additionalProperties" => false,
+        "required" => [*SHARED_SUBMITTED_KEYS, 'lazy'],
+        "properties" => {
+          # Required
+          **SHARED_SUBMITTED_PROPS,
+          "job_type" => { "const" => "ARRAY" },
+          "lazy" => { "type" => "boolean" },
+          # Optional
+          "estimated_start_time" => { "type" => ['date-time', 'null'] },
+          "estimated_end_time" => { "type" => ['date-time', 'null'] },
+        }
+      })
     })
 
     def self.load_all

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -113,15 +113,14 @@ module FlightJob
         "type" => "object",
         "additionalProperties" => false,
         "required" => [
-          *SHARED_SUBMITTED_KEYS, 'state', 'stdout_path', 'stderr_path'
+          *SHARED_SUBMITTED_KEYS, 'state', 'scheduler_state'
         ],
         "properties" => {
           # Required
           **SHARED_SUBMITTED_PROPS,
           "job_type" => { "const" => "SINGLETON" },
           "state" => { "enum" => STATES },
-          "stdout_path" => { "type" => "string", "minLength" => 1 },
-          "stderr_path" => { "type" => "string", "minLength" => 1 },
+          "scheduler_state" => { "type" => "string", "minLength" => 1 },
           # Optional
           #
           # NOTE: The transient dependency between 'state' and times
@@ -135,7 +134,8 @@ module FlightJob
           "end_time" => { "type" => ["date-time", "null"] },
           "reason" => { "type" => ["string", "null"] },
           # Optional - Non empty
-          "scheduler_state" => { "type" => "string", "minLength" => 1 },
+          "stdout_path" => { "type" => "string", "minLength" => 1 },
+          "stderr_path" => { "type" => "string", "minLength" => 1 },
         }
       }),
 

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -102,7 +102,7 @@ module FlightJob
         "additionalProperties" => false,
         "required" => [
           *SHARED_KEYS, 'submit_status', 'submit_stdout', 'submit_stderr',
-          'scheduler_id', 'state', 'results_dir', 'stdout_path'
+          'scheduler_id', 'state', 'results_dir', 'stdout_path', 'stderr_path'
         ],
         "properties" => {
           # Required
@@ -115,6 +115,7 @@ module FlightJob
           "scheduler_id" => { "type" => "string", "minLength" => 1 },
           "results_dir" => { "type" => "string", "minLength" => 1 },
           "stdout_path" => { "type" => "string", "minLength" => 1 },
+          "stderr_path" => { "type" => "string", "minLength" => 1 },
           # Optional
           #
           # NOTE: The transient dependency between 'state' and times
@@ -129,7 +130,6 @@ module FlightJob
           "reason" => { "type" => ["string", "null"] },
           # Optional - Non empty
           "scheduler_state" => { "type" => "string", "minLength" => 1 },
-          "stderr_path" => { "type" => "string", "minLength" => 1 }
         }
       })
     }

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -377,7 +377,6 @@ module FlightJob
       return false unless stdout_path
       return false unless File.exists? stdout_path
       File.stat(stdout_path).readable?
-    rer
     end
 
     def stderr_readable?

--- a/lib/flight_job/models/task.rb
+++ b/lib/flight_job/models/task.rb
@@ -38,15 +38,13 @@ module FlightJob
       "type" => "object",
       "additionalProperties" => false,
       "required" => [
-        "version", 'state', 'stdout_path', 'stderr_path', "scheduler_state"
+        "version", 'state', "scheduler_state"
       ],
       "properties" => {
         # Required
         "version" => { "const" => 1 },
         "scheduler_state" => { "type" => "string", "minLength" => 1 },
         "state" => { "enum" => STATES },
-        "stdout_path" => { "type" => "string", "minLength" => 1 },
-        "stderr_path" => { "type" => "string", "minLength" => 1 },
         # Optional
         #
         # NOTE: The transient dependency between 'state' and times
@@ -59,6 +57,9 @@ module FlightJob
         "start_time" => { "type" => ["date-time", "null"] },
         "end_time" => { "type" => ["date-time", "null"] },
         "reason" => { "type" => ["string", "null"] },
+        # Optional - Non empty
+        "stdout_path" => { "type" => "string", "minLength" => 1 },
+        "stderr_path" => { "type" => "string", "minLength" => 1 }
       }
     })
 

--- a/lib/flight_job/models/task.rb
+++ b/lib/flight_job/models/task.rb
@@ -1,0 +1,108 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+require 'json'
+require 'json_schemer'
+
+module FlightJob
+  class Task < ApplicationModel
+    STATES = Job::STATES
+
+    # Tasks have a deliberately *similar* metadata syntax to SINGLETON jobs
+    # Proceed with caution before introducing a deviation
+    SCHEMA = JSONSchemer.schema({
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => [
+        "version", 'state', 'stdout_path', 'stderr_path', "scheduler_state"
+      ],
+      "properties" => {
+        # Required
+        "version" => { "const" => 1 },
+        "scheduler_state" => { "type" => "string", "minLength" => 1 },
+        "state" => { "enum" => STATES },
+        "stdout_path" => { "type" => "string", "minLength" => 1 },
+        "stderr_path" => { "type" => "string", "minLength" => 1 },
+        # Optional
+        #
+        # NOTE: The transient dependency between 'state' and times
+        # are enforced by the monitor scripts.
+        #
+        # It is assumed they metadata will not be edited manually,
+        # and thus will remain accurate.
+        "estimated_start_time" => { "type" => ['date-time', 'null'] },
+        "estimated_end_time" => { "type" => ['date-time', 'null'] },
+        "start_time" => { "type" => ["date-time", "null"] },
+        "end_time" => { "type" => ["date-time", "null"] },
+        "reason" => { "type" => ["string", "null"] },
+      }
+    })
+
+    # The job_id/task_index is stored within the metadata_path,
+    # and must be injected onto the object
+    attr_accessor :job_id, :index
+    validates :job_id, presence: true
+    validates :index, presence: true
+
+    validate on: [:load, :save_metadata] do
+      # Run the initial schema, followed by the specific one
+      schema_errors = SCHEMA.validate(metadata).to_a
+
+      # Add the schema errors if any
+      unless schema_errors.empty?
+        FlightJob.logger.debug("The following metadata file is invalid: #{metadata_path}\n") do
+          JSON.pretty_generate(schema_errors)
+        end
+        errors.add(:metadata, 'is invalid')
+      end
+    end
+
+    def tag
+      "#{job_id}.#{index}"
+    end
+
+    def metadata_path
+      @metadata_path ||= File.join(task_dir, "metadata.#{index}.yaml")
+    end
+
+    def metadata
+      @metadata ||= if File.exists? metadata_path
+        YAML.load File.read(metadata_path)
+      else
+        { "version" => 1 }
+      end
+    end
+
+    private
+
+    # NOTE: Requires parity with job_dir
+    def task_dir
+      @task_dir ||= File.join(FlightJob.config.jobs_dir, job_id, 'tasks')
+    end
+  end
+end
+

--- a/libexec/job/slurm/monitor-array.sh
+++ b/libexec/job/slurm/monitor-array.sh
@@ -54,6 +54,12 @@ read -r -d '' task_template <<'TEMPLATE' || true
   reason: (
     if $reason == "" then null else $reason end
   ),
+  stdout_path: (
+    if $stdout_path == "" then null else $stdout_path end
+  ),
+  stderr_path: (
+    if $stderr_path == "" then null else $stderr_path end
+  ),
   start_time: (
     if $start_time == ""  then null else $start_time end
   ),
@@ -96,12 +102,16 @@ if [[ "$exit_status" -eq 0 ]]; then
       end_time=$(             parse_scontrol_end_time   "$line" "$state")
       estimated_start_time=$( parse_scontrol_estimated_start_time "$line" "$state")
       estimated_end_time=$(   parse_scontrol_estimated_end_time   "$line" "$state")
+      stdout_path=$(          parse_scontrol_stdout "$line")
+      stderr_path=$(          parse_scontrol_stderr "$line")
 
       json=$( \
         echo '{}' | jq  \
           --arg state "$state" \
           --arg scheduler_state "$scheduler_state" \
           --arg reason "$reason" \
+          --arg stdout_path "$stdout_path" \
+          --arg stderr_path "$stderr_path" \
           --arg estimated_start_time "$estimated_start_time" \
           --arg estimated_end_time "$estimated_end_time" \
           --arg start_time "$start_time" \
@@ -149,6 +159,8 @@ EOF
           --arg state "$state" \
           --arg scheduler_state "$scheduler_state" \
           --arg reason "$reason" \
+          --arg stdout_path "" \
+          --arg stderr_path "" \
           --arg estimated_start_time "$estimated_start_time" \
           --arg estimated_end_time "$estimated_end_time" \
           --arg start_time "$start_time" \

--- a/libexec/job/slurm/monitor-array.sh
+++ b/libexec/job/slurm/monitor-array.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+#-------------------------------------------------------------------------------
+# WARNING - README
+#
+# This is an internally managed file, any changes maybe lost on the next update!
+# Please clone the entire 'slurm' directory in order to modify this file.
+#-------------------------------------------------------------------------------
+
+# Ensure jq is on the path
+set -e
+which "jq" >/dev/null
+set +e
+
+# Source the parser
+source "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/parser.sh"
+
+# Specify the template for the JSON response
+# NOTE: scontrol does not distinguish between actual/estimated times. Instead
+#       flight-job will set the times according to the state
+read -r -d '' task_template <<'TEMPLATE' || true
+{
+  version: 1,
+  state: (
+    if $state == "" then "UNKNOWN" else $state end
+  ),
+  scheduler_state: ($scheduler_state),
+  reason: (
+    if $reason == "" then null else $reason end
+  ),
+  start_time: (
+    if $start_time == ""  then null else $start_time end
+  ),
+  end_time: (
+    if $end_time == "" then null else $end_time end
+  ),
+  estimated_start_time: (
+    if $estimated_start_time == "" then null else $estimated_start_time end
+  ),
+  estimated_end_time: (
+    if $estimated_end_time == "" then null else $estimated_end_time end
+  )
+}
+TEMPLATE
+
+# Define the tasks variables
+lazy="false"
+tasks=""
+
+# Fetch the state of the job
+raw_control=$(scontrol show job "$1" --oneline 2>&1)
+exit_status="$?"
+cat <<EOF >&2
+scontrol:
+$raw_control
+EOF
+
+if [[ "$exit_status" -eq 0 ]]; then
+  while IFS= read -r line; do
+    index=$(parse_scontrol_task_index "$line")
+    if echo "$index" | grep '-' >/dev/null; then
+      # Skipping the pseudo-task entry, setting the lazy create flag
+      lazy="true"
+    else
+      # Generate and store the JSON for the task
+      state=$(                parse_scontrol_state  "$line")
+      scheduler_state=$(      parse_scontrol_scheduler_state "$line")
+      reason=$(               parse_scontrol_reason "$line")
+      start_time=$(           parse_scontrol_start_time "$line" "$state")
+      end_time=$(             parse_scontrol_end_time   "$line" "$state")
+      estimated_start_time=$( parse_scontrol_estimated_start_time "$line" "$state")
+      estimated_end_time=$(   parse_scontrol_estimated_end_time   "$line" "$state")
+
+      json=$( \
+        echo '{}' | jq  \
+          --arg state "$state" \
+          --arg scheduler_state "$scheduler_state" \
+          --arg reason "$reason" \
+          --arg estimated_start_time "$estimated_start_time" \
+          --arg estimated_end_time "$estimated_end_time" \
+          --arg start_time "$start_time" \
+          --arg end_time "$end_time" \
+          "$task_template" \
+      )
+      tasks="$tasks, \"$index\" : $json"
+    fi
+  done <<< "$raw_control"
+elif [[ "$raw_control" == "slurm_load_jobs error: Invalid job id specified" ]]; then
+  # Fallback to sacct if scontrol does not recognise the ID
+  raw_acct=$(sacct --noheader --parsable --jobs "$1" --format State,Reason,START,END,AllocTRES,JobID)
+  exit_status="$?"
+  cat <<EOF >&2
+
+sacct:
+$raw_acct
+EOF
+
+  # Remove every second line from output
+  # NOTE: sacct output looks something like this:
+  #
+  # COMPLETED|None|2021-09-01T15:58:03|2021-09-01T15:58:03|billing=1,cpu=1,mem=1M,node=1|155_1|
+  # COMPLETED||2021-09-01T15:58:03|2021-09-01T15:58:03|cpu=1,mem=1M,node=1|155_1.batch|
+  acct=$(echo "$raw_acct" | awk 'FNR%2')
+
+  if [[ "$exit_status" -eq 0 ]] && [ -z "$acct" ]; then
+    # NOOP
+    echo "No Tasks Found!" >&2
+
+  elif [[ "$exit_status" -eq 0 ]]; then
+    while IFS= read -r line; do
+      state=$(                parse_sacct_state  "$line")
+      scheduler_state=$(      parse_sacct_scheduler_state "$line")
+      reason=$(               parse_sacct_reason "$line")
+      start_time=$(           parse_sacct_start_time "$line" "$state")
+      end_time=$(             parse_sacct_end_time   "$line" "$state")
+      estimated_start_time=$( parse_sacct_estimated_start_time "$line" "$state")
+      estimated_end_time=$(   parse_sacct_estimated_end_time   "$line" "$state")
+
+      # Generate the index/json
+      index=$(parse_sacct_task_index "$line")
+      json=$( \
+        echo '{}' | jq  \
+          --arg state "$state" \
+          --arg scheduler_state "$scheduler_state" \
+          --arg reason "$reason" \
+          --arg estimated_start_time "$estimated_start_time" \
+          --arg estimated_end_time "$estimated_end_time" \
+          --arg start_time "$start_time" \
+          --arg end_time "$end_time" \
+          "$task_template" \
+      )
+
+      # Store the task as a JSON fragment
+      tasks="$tasks, \"$index\" : $json"
+    done <<< "$acct"
+
+  # Exit the monitor process if sacct fails to prevent the job being updated
+  else
+    echo "$sacct" >&3
+    exit "$exit_status"
+  fi
+else
+  # Exit the monitor process if scontrol fails to prevent the job being updated
+  exit "$exit_status"
+fi
+
+# Reform tasks into valid JSON (remove leading comma/ add braces)
+tasks=$(echo "$tasks" | sed 's/^,//g')
+tasks="{ $tasks }"
+
+# Render the response JSON
+read -r -d '' template <<'TEMPLATE' || true
+{
+  version: 1,
+  lazy: (if $lazy == "true" then true else false end),
+  tasks: ($tasks)
+}
+TEMPLATE
+echo '{}' | jq  \
+  --arg lazy "$lazy" \
+  --argjson tasks "$tasks" \
+  "$template" | tr -d "\n"

--- a/libexec/job/slurm/parser.sh
+++ b/libexec/job/slurm/parser.sh
@@ -147,6 +147,11 @@ function parse_scontrol_scheduler_id {
   fi
 }
 
+function parse_scontrol_task_index {
+  local control=$(echo "$1" | head -n 1 | tr ' ' '\n')
+  echo "$control" | grep '^ArrayTaskId=' | cut -d= -f2
+}
+
 function parse_scontrol_state {
   local scheduler_state=$(parse_scontrol_scheduler_state "$1")
   _parse_state "$scheduler_state"
@@ -215,7 +220,7 @@ function parse_scontrol_estimated_end_time {
 # sacct parsers
 #
 # NOTE: All sacct parsers are designed for a single row with:
-#       --format State,Reason,START,END,AllocTRES
+#       --format State,Reason,START,END,AllocTRES,JobID
 # ==============================================================================
 
 function parse_sacct_state {
@@ -262,4 +267,9 @@ function parse_sacct_estimated_end_time {
   local state="$2"
   local time=$(echo "$1" | cut -d'|' -f4)
   _parse_estimated_end_time "$time" "$state"
+}
+
+function parse_sacct_task_index {
+  local state="$2"
+  echo "$1" | cut -d'|' -f6 | sed 's/^.*_//g'
 }

--- a/libexec/job/slurm/submit.sh
+++ b/libexec/job/slurm/submit.sh
@@ -43,7 +43,7 @@ which "jq" >/dev/null
 # Specify the template for the JSON response
 read -r -d '' template <<'TEMPLATE' || true
 {
-  version: 0,
+  version: 1,
   id: ($id),
   stdout: ($stdout),
   stderr: ($stderr),

--- a/libexec/job/slurm/submit.sh
+++ b/libexec/job/slurm/submit.sh
@@ -95,8 +95,6 @@ if [ "$(parse_scontrol_job_type "$raw_control")" == "SINGLETON" ]; then
   version: 1,
   job_type: "SINGLETON",
   id: ($id),
-  stdout: ($stdout),
-  stderr: ($stderr),
   results_dir: ($results_dir)
 }
 TEMPLATE
@@ -104,8 +102,6 @@ TEMPLATE
   # Render and return the JSON payload
   echo '{}' | jq  \
     --arg id      "$(parse_scontrol_scheduler_id "$raw_control")" \
-    --arg stdout  "$(parse_scontrol_stdout "$raw_control") " \
-    --arg stderr  "$(parse_scontrol_stderr "$raw_control") " \
     --arg results_dir "$results_dir" \
     "$template" | tr -d "\n"
 else

--- a/libexec/job/slurm/submit.sh
+++ b/libexec/job/slurm/submit.sh
@@ -110,7 +110,6 @@ else
   version: 1,
   job_type: "ARRAY",
   id: ($id),
-  lazy: true,
   results_dir: ($results_dir)
 }
 TEMPLATE


### PR DESCRIPTION
This PR is based on #41 

---

This PR does the following:

* Add's the `ARRAY` job metadata syntax,
* Creates the array `Task` object,
* Updates the response syntax for `submit.sh` and
* Adds the `monitor-array.sh`

---

## ARRAY job metadata syntax

The new `ARRAY` job metadata syntax is slightly different to that of a `SINGLETON` job. This is because an array "job" does not _technically_ get ran by the scheduler. Instead, the scheduler will spawn array `tasks`.

This has the following implications for the array `job`:
* It does not have a _direct_ `start_time`/`end_time`,
* The `estimated_start_time`/`estimated_end_time` are slight misnomers,
* It does not have a `scheduler_state`, and
* It does not have a _direct_ `state`.

Most of the above attributes can be inferred from the `tasks`. Doing this will be implemented in a future PR.

---

## Array Tasks

An array `job` should start many `tasks`, which are saved as separate metadata files:

```
<lib-dir>/jobs/<job-id>/tasks/metadata.<index>.yaml
```

The metadata syntax is broadly based of a `SINGLETON` job type. The major differences being `tasks`:

* Do not have the `submit_*` attributes, and
* They must be created with a `scheduler_state`.

Displaying the tasks through the CLI will be implemented in a future PR.

---

## Updating Submit.sh

The `submit.sh` script must now report back if the job is a `SINGLETON` or an `ARRAY` job. This will trigger the job type being updated accordingly.

The `submit.sh` no longer reports back the `stdout`/`stderr` paths. This done for two reasons:

* Array `TASKS` must be created via the `monitor-array.sh` script, and
* Ideally there should be parity between `monitor.sh`/`monitor-array.sh` where possible.

The appropriate monitor script is now ran immediately after `submit.sh`. This should ensure the paths are set.

---

## Add the monitor-array.sh

Array `tasks` are created on the fly when the `job` is monitored. This is done by a dedicated `monitor-array.sh` script. This script is broadly based on `monitor.sh`.