### PR TITLE
Implement the cancel-job command

### DIFF
--- a/config/schemas/job/version1.json
+++ b/config/schemas/job/version1.json
@@ -302,6 +302,9 @@
         "lazy": {
           "type": "boolean"
         },
+        "cancelled": {
+          "type": "boolean"
+        },
         "estimated_start_time": {
           "type": [
             "date-time",

--- a/config/schemas/job/version1.template.yaml
+++ b/config/schemas/job/version1.template.yaml
@@ -94,6 +94,7 @@ oneOf:
       <<: *SUBMITTED_PROPERTIES
       job_type: { "const" : "ARRAY" }
       lazy: { "type" : "boolean" }
+      cancelled: { "type" : "boolean" }
       # Optional
       estimated_start_time: { "type" : ['date-time', 'null'] }
       estimated_end_time: { "type" : ['date-time', 'null'] }

--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -103,6 +103,19 @@
 # monitor_array_script_path: libexec/job/<scheduler>/monitor-array.sh
 
 # ==============================================================================
+# Cancel Script Path
+# Specify the path to the script which cancels jobs.
+#
+# The default value will automatically use the 'scheduler' config. This feature
+# is not supported when overridden.
+#
+# Relative paths are expanded from flight_ROOT. **
+#
+# The environment variable flight_JOB_cancel_script_path takes precedence.
+# ==============================================================================
+# cancel_script_path: libexec/job/<scheduler>/cancel.sh
+
+# ==============================================================================
 # Script Adapter Path
 # Specify the path to the script adapter/shim. This adapter will be rendered
 # between the 'directives' and 'workload' sections of the job's script. It is

--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -109,7 +109,8 @@
 # The default value will automatically use the 'scheduler' config. This feature
 # is not supported when overridden.
 #
-# Relative paths are expanded from flight_ROOT. **
+# Relative paths are expanded according to the "Relative path expansion" rules
+# described below.
 #
 # The environment variable flight_JOB_cancel_script_path takes precedence.
 # ==============================================================================

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -206,8 +206,12 @@ module FlightJob
       end
     end
 
+    create_command 'cancel-job', 'JOB_ID' do |c|
+      c.summary = 'Cancel the specified job'
+    end
+
     create_command 'delete-job', 'JOB_ID' do |c|
-      c.summary = 'Permanently remove a job'
+      c.summary = 'Permanently the record of a job'
     end
 
     create_command 'list-array-tasks', 'JOB_ID' do |c|

--- a/lib/flight_job/cli.rb
+++ b/lib/flight_job/cli.rb
@@ -211,7 +211,12 @@ module FlightJob
     end
 
     create_command 'delete-job', 'JOB_ID' do |c|
-      c.summary = 'Permanently the record of a job'
+      c.summary = 'Permanently remove the specified job'
+      c.description = <<~DESC.chomp
+      This will permanently remove the Flight Job record of the specified job.
+      If a record is kept elsewhere such as the HPC scheduler's accouting
+      database, that record will not be affected.
+      DESC
     end
 
     create_command 'list-array-tasks', 'JOB_ID' do |c|

--- a/lib/flight_job/commands/cancel_job.rb
+++ b/lib/flight_job/commands/cancel_job.rb
@@ -33,13 +33,13 @@ module FlightJob
         if job.cancel
           # The job may not have been cancelled by this point, so the current
           # state is displayed
-          puts render_output(Outputs::InfoJob, job)
+          puts render_output(Outputs::InfoJob, job.decorate)
         else
           # This is an intentional misnomer
           #
           # There are race conditions between Job#cancel and the job otherwise
-          # terminating naturally
-          raise InputError, "Can not cancel terminated job: #{id}"
+          # terminating naturally.
+          raise InputError, "Cannot cancel terminated job: #{id}"
         end
       end
     end

--- a/lib/flight_job/commands/cancel_job.rb
+++ b/lib/flight_job/commands/cancel_job.rb
@@ -1,0 +1,48 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+module FlightJob
+  module Commands
+    class CancelJob < Command
+      def run
+        job = load_job(args.first)
+        if job.cancel
+          # The job may not have been cancelled by this point, so the current
+          # state is displayed
+          puts render_output(Outputs::InfoJob, job)
+        else
+          # This is an intentional misnomer
+          #
+          # There are race conditions between Job#cancel and the job otherwise
+          # terminating naturally
+          raise InputError, "Can not cancel terminated job: #{id}"
+        end
+      end
+    end
+  end
+end
+

--- a/lib/flight_job/commands/delete_job.rb
+++ b/lib/flight_job/commands/delete_job.rb
@@ -25,14 +25,35 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 
+require 'tty-prompt'
+
 module FlightJob
   module Commands
     class DeleteJob < Command
       def run
         job = load_job(args.first)
+
+        if $stdout.tty? && !job.terminal?
+          $stderr.puts pastel.red <<~WARN.chomp
+            Job '#{job.id}' is currently #{job.state}!
+            You should first cancel the job with:
+          WARN
+          $stderr.puts pastel.yellow "#{CLI.program(:name)} cancel-job #{args.first}"
+          $stderr.puts
+          if prompt.no? pastel.bold("Do you wish to delete the job anyway?")
+            raise InputError, "The job has not been deleted"
+          end
+        end
+
         FlightJob.logger.warn "Permanently removing job: #{job.id}"
         FileUtils.rm_rf File.dirname(job.metadata_path)
         $stderr.puts "Removed job: #{job.id}"
+      end
+
+      private
+
+      def prompt
+        @prompt ||= TTY::Prompt.new(help_color: :yellow)
       end
     end
   end

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -69,6 +69,11 @@ module FlightJob
               transform: relative_to(root_path)
     validates :submit_script_path, presence: true
 
+    attribute :cancel_script_path,
+              default: ->(config) { File.join('libexec/job', config.scheduler, 'cancel.sh') },
+              transform: relative_to(root_path)
+    validates :cancel_script_path, presence: true
+
     attribute :monitor_script_path,
               default: ->(config) { File.join('libexec/job', config.scheduler, 'monitor.sh') },
               transform: relative_to(root_path)

--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -64,11 +64,10 @@ module FlightJob
             'RUNNING'
           elsif states.include?('PENDING')
             'PENDING'
+          elsif object.metadata['cancelled']
+            'CANCELLED'
           elsif object.metadata['lazy']
             'HOLD'
-          elsif object.metadata['cancelled']
-            # NOTE: Not currently supported
-            'CANCELLED'
           elsif states == ['COMPLETED']
             'COMPLETED'
           else

--- a/lib/flight_job/help_formatter.rb
+++ b/lib/flight_job/help_formatter.rb
@@ -105,7 +105,7 @@ module FlightJob
     end
 
     def command_prefix_order
-      @command_prefix_order ||= ['list', 'create', 'submit', 'info', 'view', 'edit', 'delete']
+      @command_prefix_order ||= ['list', 'create', 'submit', 'info', 'view', 'edit', 'cancel', 'delete']
     end
 
     def commands_by_section

--- a/lib/flight_job/job_transitions/cancel_transition.rb
+++ b/lib/flight_job/job_transitions/cancel_transition.rb
@@ -1,0 +1,86 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+module FlightJob
+  module JobTransitions
+    class CancelTransition
+      def initialize(job)
+        @job = job
+      end
+
+      def run
+        if @job.terminal?
+          # In practice, this condition shouldn't be reached. However preventing it
+          # is up to the CLI's implementation
+          FlightJob.logger.info "Cancelling Terminated Job: #{@job.id}"
+        else
+          FlightJob.logger.info "Cancelling Job: #{@job.id}"
+        end
+
+        cmd = [Flight.config.cancel_script_path, @job.scheduler_id]
+        execute_command(*cmd, tag: 'cancel') do |status, _o, _e|
+          # Run the monitor when:
+          # * Cancel runs successful, or
+          # * If the job is non-terminal (it may have changed)
+          @job.monitor if status.success? || @job.terminal?
+          if status.success?
+            true
+          elsif @job.terminal?
+            false
+          else
+            raise CommandError, <<~ERROR.chomp
+            Unexpectedly failed to cancel job '#{@job.id}'!
+            Please contact your system administrator for futher assistance.
+            ERROR
+          end
+        end
+      end
+
+      private
+
+      def execute_command(*cmd, tag:)
+        env = ENV.slice('PATH', 'HOME', 'USER', 'LOGNAME')
+        cmd_stdout, cmd_stderr, status = Open3.capture3(env, *cmd, unsetenv_others: true, close_others: true)
+
+        unless status.success?
+          FlightJob.logger.error("Failed to #{tag} job: #{@job.id}")
+        end
+
+        FlightJob.logger.debug <<~DEBUG
+          COMMAND: #{cmd.join(" ")}
+          STATUS: #{status.exitstatus}
+          STDOUT:
+          #{cmd_stdout}
+          STDERR:
+          #{cmd_stderr}
+        DEBUG
+
+        yield(status, cmd_stdout, cmd_stderr)
+      end
+    end
+  end
+end

--- a/lib/flight_job/job_transitions/monitor_array_transition.rb
+++ b/lib/flight_job/job_transitions/monitor_array_transition.rb
@@ -37,6 +37,7 @@ module FlightJob
         "properties" => {
           "version" => { "const" => 1 },
           "lazy" => { "type" => "boolean" },
+          "cancelled" => { "type" => "boolean" },
           "tasks" => {
             "type" => "object",
             "additionalProperties" => false, # Redundant, probably ...
@@ -54,43 +55,57 @@ module FlightJob
         cmd = [FlightJob.config.monitor_array_script_path, scheduler_id]
         execute_command(*cmd, tag: 'monitor') do |status, stdout, stderr, data|
           if status.success?
-            # Validate the output
-            validate_data(SCHEMA, data, tag: "monitor-array")
-            data['tasks'].each do |index, datum|
-              validate_data(TASK_SCHEMAS[:common], datum, tag: "monitor-array task: #{index} (common)")
-              state = datum['state']
-              validate_data(TASK_SCHEMAS[state], datum, tag: "monitor-array task: #{index} (#{state})")
-            end
-
-            # Builds each task
-            tasks = data['tasks'].map do |index, datum|
-              Task.new(job_id: id, index: index).tap do |task|
-                apply_task_attributes(task, datum)
-              end
-            end
-
-            # Log and raise any invalid tasks
-            invalid_tasks = tasks.reject { |t| t.valid?(:save_metadata) }
-            unless invalid_tasks.empty?
-              invalid_tasks.each do |task|
-                FlightJob.logger.error("Failed to save task metadata: #{task.tag}")
-                FlightJob.logger.info(errors.full_messages.join("\n"))
-              end
-              raise InternalError, <<~ERROR.chomp
-                Unexpectedly failed to monitor '#{id}' due to invalid task(s)!
-              ERROR
-            end
-
-            # Save all the tasks metadata
-            tasks.each { |t| t.save_metadata(validate: false) }
-
-            # Update the lazy flag
-            metadata["lazy"] = data["lazy"]
-            save_metadata
+            validate_response(data)
+            update_tasks(data)
+            update_job(data)
 
             # Remove the indexing file in terminal state
             # FileUtils.rm_f active_index_path if terminal?
           end
+        end
+      end
+
+      private
+
+      def validate_response(data)
+        validate_data(SCHEMA, data, tag: "monitor-array")
+        data['tasks'].each do |index, datum|
+          validate_data(TASK_SCHEMAS[:common], datum, tag: "monitor-array task: #{index} (common)")
+          state = datum['state']
+          validate_data(TASK_SCHEMAS[state], datum, tag: "monitor-array task: #{index} (#{state})")
+        end
+      end
+
+      def update_tasks(data)
+        tasks = build_tasks(data)
+        assert_tasks_valid(tasks)
+        tasks.each { |t| t.save_metadata(validate: false) }
+      end
+
+      def update_job(data)
+        metadata["cancelled"] = data["cancelled"]
+        metadata["lazy"] = data["lazy"]
+        save_metadata
+      end
+
+      def build_tasks(data)
+        data['tasks'].map do |index, datum|
+          Task.new(job_id: id, index: index).tap do |task|
+            apply_task_attributes(task, datum)
+          end
+        end
+      end
+
+      def assert_tasks_valid(tasks)
+        invalid_tasks = tasks.reject { |t| t.valid?(:save_metadata) }
+        unless invalid_tasks.empty?
+          invalid_tasks.each do |task|
+            FlightJob.logger.error("Failed to save task metadata: #{task.tag}")
+            FlightJob.logger.info(errors.full_messages.join("\n"))
+          end
+          raise InternalError, <<~ERROR.chomp
+            Unexpectedly failed to monitor '#{id}' due to invalid task(s)!
+          ERROR
         end
       end
     end

--- a/lib/flight_job/job_transitions/submit_transition.rb
+++ b/lib/flight_job/job_transitions/submit_transition.rb
@@ -115,6 +115,7 @@ module FlightJob
             metadata['state'] = 'PENDING'
             MonitorSingletonTransition.new(__getobj__).run
           when 'ARRAY'
+            metadata['cancelled'] = false
             MonitorArrayTransition.new(__getobj__).run
           end
         end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -300,36 +300,7 @@ module FlightJob
     end
 
     def cancel
-      if terminal?
-        # In practice, this condition shouldn't be reached. However preventing it
-        # is up to the CLI's implementation
-        FlightJob.logger.warn "Cancelling Terminated Job: #{id}"
-      else
-        FlightJob.logger.warn "Cancelling Job: #{id}"
-      end
-
-      execute_command(Flight.config.cancel_script_path, scheduler_id) do |status, _o, _e|
-        # Run the monitor when:
-        # * Cancel runs successful, or
-        # * If the job is non-terminal (it may have changed)
-        monitor if status.success? || terminal?
-
-        # Notify the cancel succeeded
-        if status.success?
-          true
-
-        # Notify the cancel failed, but the job is otherwise terminated
-        elsif terminal?
-          false
-
-        # Error due to the cancel failing
-        else
-          raise CommandError, <<~ERROR.chomp
-            Unexpectedly failed to cancel job '#{id}'!
-            Please contact your system administrator for futher assistance.
-          ERROR
-        end
-      end
+      JobTransitions::CancelTransition.new(self).run
     end
 
     def decorate

--- a/libexec/job/slurm/cancel.sh
+++ b/libexec/job/slurm/cancel.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+# Run scancel
+exec scancel "$1"

--- a/libexec/job/slurm/parser.sh
+++ b/libexec/job/slurm/parser.sh
@@ -164,6 +164,11 @@ function parse_scontrol_scheduler_id {
     fi
 }
 
+parse_scontrol_job_id() {
+  local control=$(echo "$1" | head -n 1 | tr ' ' '\n')
+  echo "$control" | grep '^JobId=' | cut -d= -f2
+}
+
 function parse_scontrol_task_index {
   local control=$(echo "$1" | head -n 1 | tr ' ' '\n')
   echo "$control" | grep '^ArrayTaskId=' | cut -d= -f2
@@ -237,7 +242,7 @@ function parse_scontrol_estimated_end_time {
 # sacct parsers
 #
 # NOTE: All sacct parsers are designed for a single row with:
-#       --format State,Reason,START,END,AllocTRES,JobID
+#       --format State,Reason,START,END,AllocTRES,JobID,JobIDRaw
 # ==============================================================================
 
 function parse_sacct_state {
@@ -289,4 +294,8 @@ function parse_sacct_estimated_end_time {
 function parse_sacct_task_index {
   local state="$2"
   echo "$1" | cut -d'|' -f6 | sed 's/^.*_//g'
+}
+
+parse_sacct_job_id_raw() {
+  echo "$1" | cut -d'|' -f7
 }


### PR DESCRIPTION
A new `cancel-job` command has been added which wraps a `cancel_job_script`. For slurm, this directly calls `scontrol`. The monitor script is automatically called after a cancellation, which keeps things simple.

A prompt has been added to `delete-job` about the cancel command.