### PR TITLE
Standardise the error message for missing results_dir

### DIFF
--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -206,9 +206,9 @@ module FlightJob
       if !(job.results_dir && Dir.exists?(job.results_dir))
         case job.state
         when 'PENDING'
-          raise MissingError, 'Your job has not started, please try again latter...'
+          raise MissingError, 'Your job has not started, please try again later...'
         when *Job::RUNNING_STATES
-          raise MissingError, 'No job results found, please try again latter...'
+          raise MissingError, 'No job results found, please try again later...'
         else
           raise MissingError, 'No job results found.'
         end

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -200,18 +200,27 @@ module FlightJob
       end
     end
 
-    def assert_results_dir_exists(job)
-      # NOTE: Jobs created with old versions of flight-job will not have a
-      # results directory.
-      if !(job.results_dir && Dir.exists?(job.results_dir))
-        case job.state
-        when 'PENDING'
-          raise MissingError, 'Your job has not started, please try again later...'
-        when *Job::RUNNING_STATES
-          raise MissingError, 'No job results found, please try again later...'
-        else
-          raise MissingError, 'No job results found.'
-        end
+    def assert_results_dir_exists(job, allow_empty: true)
+      error = if !job.results_dir
+                true
+              elsif !Dir.exists?(job.results_dir)
+                true
+              elsif allow_empty
+                false
+              elsif Dir.empty?(job.results_dir)
+                true
+              else
+                false
+              end
+      return unless error
+
+      case job.state
+      when 'PENDING'
+        raise MissingError, 'Your job has not started, please try again later...'
+      when *Job::RUNNING_STATES
+        raise MissingError, 'No job results found, please try again later...'
+      else
+        raise MissingError, 'No job results found.'
       end
     end
   end

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -203,8 +203,15 @@ module FlightJob
     def assert_results_dir_exists(job)
       # NOTE: Jobs created with old versions of flight-job will not have a
       # results directory.
-      unless job.results_dir
-        raise MissingError, "The job did not report its results directory"
+      if !(job.results_dir && Dir.exists?(job.results_dir))
+        case job.state
+        when 'PENDING'
+          raise MissingError, 'Your job has not started, please try again latter...'
+        when *Job::RUNNING_STATES
+          raise MissingError, 'No job results found, please try again latter...'
+        else
+          raise MissingError, 'No job results found.'
+        end
       end
     end
   end

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -37,16 +37,17 @@ module FlightJob
 
       def run
         job = load_job(args.first)
-        assert_results_dir_exists(job, allow_empty: hard_wrap?)
+        assert_results_dir_exists(job, allow_empty: advanced?)
 
         FlightJob.logger.debug "Running: ls #{job.results_dir} #{ls_options.join(" ")}"
         cmd = ['ls', job.results_dir, *ls_options]
 
-        status = if hard_wrap?
-          # When hard wrapping, emit STDOUT/STDERR directly to the terminal
+        status = if advanced?
+          # When the user has provided options to the `ls` command, emit
+          # STDOUT/STDERR directly to the terminal
           Kernel.system(*cmd)
         else
-          # When soft wrapping, hide the ls error
+          # When we control the `ls` options we provide nicer error messages.
           stdout, status = Open3.capture2(*cmd)
           puts stdout if status.success?
           status.success?
@@ -58,7 +59,8 @@ module FlightJob
 
       private
 
-      def hard_wrap?
+      # Return true if the user has provided options to `ls`.
+      def advanced?
         args.length > 1
       end
 

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -59,21 +59,8 @@ module FlightJob
           status.success?
         end
 
-        unless status
-          # Assume the directory does not exist, and give an error message according
-          # to the state
-          case job.state
-          when *Job::RUNNING_STATES
-            raise InputError, HARD_ERROR if hard_wrap?
-            raise InputError, 'Your job is currently running, please try again later...'
-          when *Job::TERMINAL_STATES
-            raise MissingError, HARD_ERROR if hard_wrap?
-            raise MissingError, 'Your job did not create the results directory!'
-          else
-            raise InputError, HARD_ERROR if hard_wrap?
-            raise InputError, 'Your job has not started yet, please try again later...'
-          end
-        end
+        # Handle errors
+        raise InternalError, HARD_ERROR unless status
       end
 
       private

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -33,7 +33,7 @@ module FlightJob
       # The 'ls' command will fail if bad arguments are provided to it. This can
       # not be easily detected as 'ls' will likely exit 2 regardless. Instead a
       # generic error is raised instead.
-      HARD_ERROR = "An error occurred when running the 'ls' command!"
+      LS_ERROR = "An error occurred when running the 'ls' command!"
 
       def run
         job = load_job(args.first)
@@ -52,7 +52,7 @@ module FlightJob
             if Job::TERMINAL_STATES.include?(job.state)
               $stderr.puts pastel.yellow 'No job results found.'
             else
-              $stderr.puts pastel.yellow 'No job results found, please try again latter...'
+              $stderr.puts pastel.yellow 'No job results found, please try again later...'
             end
           elsif status.success?
             puts stdout
@@ -61,7 +61,7 @@ module FlightJob
         end
 
         # Handle errors
-        raise InternalError, HARD_ERROR unless status
+        raise InternalError, LS_ERROR unless status
       end
 
       private

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -37,7 +37,13 @@ module FlightJob
 
       def run
         job = load_job(args.first)
-        assert_results_dir_exists(job)
+
+        # Skip the assertion check when hard wrapping and the directory exists
+        # This causes to command to run on empty directories
+        if hard_wrap? && Dir.exists?(job.results_dir)
+          assert_results_dir_exists(job)
+        end
+
         FlightJob.logger.debug "Running: ls #{job.results_dir} #{ls_options.join(" ")}"
         cmd = ['ls', job.results_dir, *ls_options]
 

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -37,12 +37,7 @@ module FlightJob
 
       def run
         job = load_job(args.first)
-
-        # Skip the assertion check when hard wrapping and the directory exists
-        # This causes to command to run on empty directories
-        if hard_wrap? && Dir.exists?(job.results_dir)
-          assert_results_dir_exists(job)
-        end
+        assert_results_dir_exists(job)
 
         FlightJob.logger.debug "Running: ls #{job.results_dir} #{ls_options.join(" ")}"
         cmd = ['ls', job.results_dir, *ls_options]

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -37,7 +37,7 @@ module FlightJob
 
       def run
         job = load_job(args.first)
-        assert_results_dir_exists(job)
+        assert_results_dir_exists(job, allow_empty: hard_wrap?)
 
         FlightJob.logger.debug "Running: ls #{job.results_dir} #{ls_options.join(" ")}"
         cmd = ['ls', job.results_dir, *ls_options]
@@ -48,15 +48,7 @@ module FlightJob
         else
           # When soft wrapping, hide the ls error
           stdout, status = Open3.capture2(*cmd)
-          if status.success? && stdout.empty?
-            if Job::TERMINAL_STATES.include?(job.state)
-              $stderr.puts pastel.yellow 'No job results found.'
-            else
-              $stderr.puts pastel.yellow 'No job results found, please try again later...'
-            end
-          elsif status.success?
-            puts stdout
-          end
+          puts stdout if status.success?
           status.success?
         end
 


### PR DESCRIPTION
The distinction between a job not reporting its `results_dir` and the directory not existing as been removed.

Moving forward, all successfully submitted jobs will have a `results_dir`. A generic "no results found" is emitted when the directory does not exist. The same error is emitted for failed submissions.