### PR TITLE
Refactor the transition classes

### DIFF
--- a/lib/flight_job/job_transitions/array_monitor.rb
+++ b/lib/flight_job/job_transitions/array_monitor.rb
@@ -27,7 +27,7 @@
 
 module FlightJob
   module JobTransitions
-    class MonitorArrayTransition < SimpleDelegator
+    class ArrayMonitor < SimpleDelegator
       include JobTransitions::JobTransitionHelper
 
       SCHEMA = JSONSchemer.schema({
@@ -48,7 +48,7 @@ module FlightJob
           }
         }
       })
-      TASK_SCHEMAS = MonitorSingletonTransition::SCHEMAS
+      TASK_SCHEMAS = SingletonMonitor::SCHEMAS
 
       def run
         FlightJob.logger.info("Monitoring Job: #{id}")

--- a/lib/flight_job/job_transitions/array_monitor.rb
+++ b/lib/flight_job/job_transitions/array_monitor.rb
@@ -101,9 +101,9 @@ module FlightJob
       end
 
       def update_job(data)
-        metadata["cancelled"] = data["cancelled"]
-        metadata["lazy"] = data["lazy"]
-        save_metadata
+        job.metadata["cancelled"] = data["cancelled"]
+        job.metadata["lazy"] = data["lazy"]
+        job.save_metadata
       end
 
       def build_tasks(data)

--- a/lib/flight_job/job_transitions/canceller.rb
+++ b/lib/flight_job/job_transitions/canceller.rb
@@ -36,7 +36,7 @@ module FlightJob
         run!
         return true
       rescue
-        Flight.logger.error "Failed to submit job '#{id}'"
+        Flight.logger.error "Failed to submit job '#{job.id}'"
         Flight.logger.warn $!
         return false
       end

--- a/lib/flight_job/job_transitions/canceller.rb
+++ b/lib/flight_job/job_transitions/canceller.rb
@@ -27,7 +27,7 @@
 
 module FlightJob
   module JobTransitions
-    class CancelTransition
+    class Canceller
       def initialize(job)
         @job = job
       end

--- a/lib/flight_job/job_transitions/canceller.rb
+++ b/lib/flight_job/job_transitions/canceller.rb
@@ -33,6 +33,15 @@ module FlightJob
       end
 
       def run
+        run!
+        return true
+      rescue
+        Flight.logger.error "Failed to submit job '#{id}'"
+        Flight.logger.warn $!
+        return false
+      end
+
+      def run!
         if @job.terminal?
           # In practice, this condition shouldn't be reached. However preventing it
           # is up to the CLI's implementation

--- a/lib/flight_job/job_transitions/failed_submitter.rb
+++ b/lib/flight_job/job_transitions/failed_submitter.rb
@@ -29,6 +29,15 @@ module FlightJob
   module JobTransitions
     class FailedSubmitter < SimpleDelegator
       def run
+        run!
+        return true
+      rescue
+        Flight.logger.error "Failed to transition job '#{id}'"
+        Flight.logger.warn $!
+        return false
+      end
+
+      def run!
         # Check if the maximum pending submission time has elapsed
         start = DateTime.rfc3339(created_at).to_time.to_i
         now = Time.now.to_i

--- a/lib/flight_job/job_transitions/failed_submitter.rb
+++ b/lib/flight_job/job_transitions/failed_submitter.rb
@@ -27,7 +27,7 @@
 
 module FlightJob
   module JobTransitions
-    class FailedSubmissionTransition < SimpleDelegator
+    class FailedSubmitter < SimpleDelegator
       def run
         # Check if the maximum pending submission time has elapsed
         start = DateTime.rfc3339(created_at).to_time.to_i

--- a/lib/flight_job/job_transitions/failed_submitter.rb
+++ b/lib/flight_job/job_transitions/failed_submitter.rb
@@ -27,31 +27,31 @@
 
 module FlightJob
   module JobTransitions
-    class FailedSubmitter < SimpleDelegator
+    FailedSubmitter = Struct.new(:job) do
       def run
         run!
         return true
       rescue
-        Flight.logger.error "Failed to transition job '#{id}'"
+        Flight.logger.error "Failed to transition job '#{job.id}'"
         Flight.logger.warn $!
         return false
       end
 
       def run!
         # Check if the maximum pending submission time has elapsed
-        start = DateTime.rfc3339(created_at).to_time.to_i
+        start = DateTime.rfc3339(job.created_at).to_time.to_i
         now = Time.now.to_i
         if now - start > FlightJob.config.submission_period
           FlightJob.logger.error <<~ERROR
-            The following job is being flagged as FAILED as it has not been submitted: #{id}
+            The following job is being flagged as FAILED as it has not been submitted: #{job.id}
           ERROR
-          metadata['job_type'] = "FAILED_SUBMISSION"
-          metadata['submit_status'] = 126
-          metadata['submit_stdout'] = ''
-          metadata['submit_stderr'] = 'Failed to run the submission command for an unknown reason'
-          save_metadata
+          job.metadata['job_type'] = "FAILED_SUBMISSION"
+          job.metadata['submit_status'] = 128
+          job.metadata['submit_stdout'] = ''
+          job.metadata['submit_stderr'] = 'Failed to run the submission command for an unknown reason'
+          job.save_metadata
         else
-          FlightJob.logger.info "Ignoring the following job as it is pending submission: #{id}"
+          FlightJob.logger.info "Ignoring the following job as it is pending submission: #{job.id}"
         end
       end
     end

--- a/lib/flight_job/job_transitions/job_transition_helper.rb
+++ b/lib/flight_job/job_transitions/job_transition_helper.rb
@@ -30,20 +30,11 @@ require 'open3'
 module FlightJob
   module JobTransitions
     module JobTransitionHelper
-      # TODO: Remove me!
-      def method_missing(s, *args)
-        if respond_to? :job
-          job.send(s, *args)
-        else
-          __getobj__.send(s, *args)
-        end
-      end
-
       def execute_command(*cmd, tag:)
         # NOTE: Should the PATH be configurable instead of inherited from the environment?
         # This could lead to differences when executed via the CLI or the webapp
         env = ENV.slice('PATH', 'HOME', 'USER', 'LOGNAME').tap do |h|
-          h['CONTROLS_DIR'] = controls_dir.path
+          h['CONTROLS_DIR'] = job.controls_dir.path
         end
         cmd_stdout, cmd_stderr, status = Open3.capture3(env, *cmd, unsetenv_others: true, close_others: true)
 

--- a/lib/flight_job/job_transitions/singleton_monitor.rb
+++ b/lib/flight_job/job_transitions/singleton_monitor.rb
@@ -139,7 +139,7 @@ module FlightJob
 
       def run!
         # Skip jobs that have terminated, this allows the method to be called liberally
-        if Job::STATES_LOOKUP[job.state] == :terminal
+        if job.terminal?
           FlightJob.logger.debug "Skipping monitor for terminated job: #{job.id}"
           return
         end

--- a/lib/flight_job/job_transitions/singleton_monitor.rb
+++ b/lib/flight_job/job_transitions/singleton_monitor.rb
@@ -27,7 +27,7 @@
 
 module FlightJob
   module JobTransitions
-    class MonitorSingletonTransition < SimpleDelegator
+    class SingletonMonitor < SimpleDelegator
       include JobTransitions::JobTransitionHelper
 
       SHARED_KEYS = ["version", "state", "stdout_path", "stderr_path", "scheduler_state"]

--- a/lib/flight_job/job_transitions/submitter.rb
+++ b/lib/flight_job/job_transitions/submitter.rb
@@ -55,6 +55,15 @@ module FlightJob
       end
 
       def run
+        run!
+        return true
+      rescue
+        Flight.logger.error "Failed to submit job '#{id}'"
+        Flight.logger.warn $!
+        return false
+      end
+
+      def run!
         # Validate and load the script
         unless valid?
           Flight.logger.error("The job is not in a valid submission state: #{id}\n") do
@@ -110,10 +119,10 @@ module FlightJob
           case data['job_type']
           when 'SINGLETON'
             metadata['state'] = 'PENDING'
-            SingletonMonitor.new(__getobj__).run
+            SingletonMonitor.new(__getobj__).run!
           when 'ARRAY'
             metadata['cancelled'] = false
-            ArrayMonitor.new(__getobj__).run
+            ArrayMonitor.new(__getobj__).run!
           end
         end
       end

--- a/lib/flight_job/job_transitions/submitter.rb
+++ b/lib/flight_job/job_transitions/submitter.rb
@@ -122,6 +122,7 @@ module FlightJob
             SingletonMonitor.new(job).run!
           when 'ARRAY'
             job.metadata['cancelled'] = false
+            job.metadata['lazy'] = true
             ArrayMonitor.new(job).run!
           end
         end

--- a/lib/flight_job/job_transitions/submitter.rb
+++ b/lib/flight_job/job_transitions/submitter.rb
@@ -27,30 +27,30 @@
 
 module FlightJob
   module JobTransitions
-    class Submitter < SimpleDelegator
+    SUBMITTER_SCHEMA = JSONSchemer.schema({
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["job_type", "version", "id", "results_dir"],
+      "properties" => {
+        "version" => { "const" => 1 },
+        "id" => { "type" => "string", "minLength" => 1 },
+        "results_dir" => { "type" => "string", "minLength" => 1 },
+        "job_type" => { "enum" => ["SINGLETON", "ARRAY"] }
+      }
+    })
+
+    Submitter = Struct.new(:job) do
       include JobTransitionHelper
       include ActiveModel::Validations
 
-      SCHEMA = JSONSchemer.schema({
-        "type" => "object",
-        "additionalProperties" => false,
-        "required" => ["job_type", "version", "id", "results_dir"],
-        "properties" => {
-          "version" => { "const" => 1 },
-          "id" => { "type" => "string", "minLength" => 1 },
-          "results_dir" => { "type" => "string", "minLength" => 1 },
-          "job_type" => { "enum" => ["SINGLETON", "ARRAY"] }
-        }
-      })
-
       validate do
-        __getobj__.valid?
-        __getobj__.errors.each { |e| @errors << e }
+        job.valid?
+        job.errors.each { |e| @errors << e }
       end
 
       validate do
-        unless load_script.valid?(:load)
-          errors.add(:script, 'is missing or invalid')
+        unless job.load_script.valid?(:load)
+          job.errors.add(:script, 'is missing or invalid')
         end
       end
 
@@ -58,71 +58,71 @@ module FlightJob
         run!
         return true
       rescue
-        Flight.logger.error "Failed to submit job '#{id}'"
+        Flight.logger.error "Failed to submit job '#{job.id}'"
         Flight.logger.warn $!
         return false
       end
 
       def run!
         # Validate and load the script
-        unless valid?
-          Flight.logger.error("The job is not in a valid submission state: #{id}\n") do
-            errors.full_messages.join("\n")
+        unless job.valid?
+          Flight.logger.error("The job is not in a valid submission state: #{job.id}\n") do
+            job.errors.full_messages.join("\n")
           end
           raise InternalError, 'Unexpectedly failed to submit the job'
         end
-        script = load_script
+        script = job.load_script
 
         # Write the initial metadata
-        save_metadata
-        FileUtils.touch active_index_path
+        job.save_metadata
+        FileUtils.touch job.active_index_path
 
         # Duplicate the script into the job's directory
-        FileUtils.cp script.script_path, metadata["rendered_path"]
+        FileUtils.cp script.script_path, job.metadata["rendered_path"]
 
         # Run the submission command
-        FlightJob.logger.info("Submitting Job: #{id}")
-        cmd = [FlightJob.config.submit_script_path, metadata["rendered_path"]]
+        FlightJob.logger.info("Submitting Job: #{job.id}")
+        cmd = [FlightJob.config.submit_script_path, job.metadata["rendered_path"]]
         execute_command(*cmd, tag: 'submit') do |status, out, err, data|
           # set the status/stdout/stderr
-          metadata['submit_status'] = status.exitstatus
-          metadata['submit_stdout'] = out
-          metadata['submit_stderr'] = err
+          job.metadata['submit_status'] = status.exitstatus
+          job.metadata['submit_stdout'] = out
+          job.metadata['submit_stderr'] = err
 
           # Return early if the submission failed
           unless status.success?
-            metadata['job_type'] = 'FAILED_SUBMISSION'
-            save_metadata
-            FileUtils.rm_f active_index_path
+            job.metadata['job_type'] = 'FAILED_SUBMISSION'
+            job.save_metadata
+            FileUtils.rm_f job.active_index_path
             return
           end
 
           # Validate the payload format
           begin
-            validate_data(SCHEMA, data, tag: 'submit')
+            validate_data(SUBMITTER_SCHEMA, data, tag: 'submit')
           rescue CommandError
             # The command lied about exiting 0! It did not report the json payload
             # correctly. Changing the status to 126
-            metadata['job_type'] = 'FAILED_SUBMISSION'
-            metadata['submit_status'] = 126
-            metadata["submit_stderr"] << "\nFailed to parse JSON response"
-            save_metadata
+            job.metadata['job_type'] = 'FAILED_SUBMISSION'
+            job.metadata['submit_status'] = 126
+            job.metadata["submit_stderr"] << "\nFailed to parse JSON response"
+            job.save_metadata
             raise $!
           end
 
           # The job was submitted correctly and is now pending
-          metadata['results_dir'] = data['results_dir']
-          metadata['scheduler_id'] = data['id']
-          metadata['job_type'] = data['job_type']
+          job.metadata['results_dir'] = data['results_dir']
+          job.metadata['scheduler_id'] = data['id']
+          job.metadata['job_type'] = data['job_type']
 
           # Run the monitor
           case data['job_type']
           when 'SINGLETON'
-            metadata['state'] = 'PENDING'
-            SingletonMonitor.new(__getobj__).run!
+            job.metadata['state'] = 'PENDING'
+            SingletonMonitor.new(job).run!
           when 'ARRAY'
-            metadata['cancelled'] = false
-            ArrayMonitor.new(__getobj__).run!
+            job.metadata['cancelled'] = false
+            ArrayMonitor.new(job).run!
           end
         end
       end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -268,13 +268,17 @@ module FlightJob
     end
 
     def monitor
-      case job_type
+      original_metadata = @metadata.deep_dup
+      success = case job_type
       when 'SUBMITTING'
         JobTransitions::FailedSubmitter.new(self).run
       when 'SINGLETON'
         JobTransitions::SingletonMonitor.new(self).run
       when 'ARRAY'
         JobTransitions::ArrayMonitor.new(self).run
+      end
+      unless success
+        @metadata = original_metadata
       end
     end
 

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -264,22 +264,22 @@ module FlightJob
     end
 
     def submit
-      JobTransitions::SubmitTransition.new(self).run
+      JobTransitions::Submitter.new(self).run
     end
 
     def monitor
       case job_type
-      when 'INITIALIZING'
-        JobTransitions::FailedSubmissionTransition.new(self).run
+      when 'SUBMITTING'
+        JobTransitions::FailedSubmitter.new(self).run
       when 'SINGLETON'
-        JobTransitions::MonitorSingletonTransition.new(self).run
+        JobTransitions::SingletonMonitor.new(self).run
       when 'ARRAY'
-        JobTransitions::MonitorArrayTransition.new(self).run
+        JobTransitions::ArrayMonitor.new(self).run
       end
     end
 
     def cancel
-      JobTransitions::CancelTransition.new(self).run
+      JobTransitions::Canceller.new(self).run
     end
 
     def decorate

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -264,7 +264,7 @@ module FlightJob
     end
 
     def submit
-      JobTransitions::Submitter.new(self).run
+      JobTransitions::Submitter.new(self).run!
     end
 
     def monitor
@@ -279,7 +279,7 @@ module FlightJob
     end
 
     def cancel
-      JobTransitions::Canceller.new(self).run
+      JobTransitions::Canceller.new(self).run!
     end
 
     def decorate

--- a/lib/flight_job/models/job/validator.rb
+++ b/lib/flight_job/models/job/validator.rb
@@ -62,11 +62,6 @@ module FlightJob
         else
           FileUtils.touch job.active_index_path
         end
-
-        # TODO: Properly do this
-        if (job.metadata || {}).to_h['job_type'] == 'ARRAY'
-          FileUtils.touch job.active_index_path
-        end
       end
 
       # This isn't really validation, but we want to run it every time a job


### PR DESCRIPTION
This PR reworks the transition classes to be a bit cleaner:

* Renames the classes to be based on nouns
* Removes the use of `SimpleDelegator`
* Error on `run!` if the transition fails, and
* Allow errors in the `run` methods.

The `Job#monitor` method now calls the `run` version of the transitions. The monitor can always be re-ran at a future date, so errors are allowed. The metadata is however reset if the transition fails.

The `cancel`/`submit` methods call the `run!` to trigger a command error.

---

Also fixed a bug where terminal array jobs where always monitored.