### PR TITLE
Small changes to task sorting, timeouts, and job state

### DIFF
--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -183,7 +183,7 @@
 #
 # The environment variable flight_JOB_submission_period takes precedence.
 # ==============================================================================
-# submission_period: 3600
+# submission_period: 300
 
 # ==============================================================================
 # Log Path

--- a/lib/flight_job/commands/list_array_tasks.rb
+++ b/lib/flight_job/commands/list_array_tasks.rb
@@ -37,7 +37,13 @@ module FlightJob
       end
 
       def tasks
-        @tasks ||= Task.load_job_tasks(args.first)
+        @tasks ||=
+          begin
+            # Load the job so as to cause it to be monitored and the list of tasks
+            # updated as a side-effect.
+            load_job(args.first)
+            Task.load_job_tasks(args.first)
+          end
       end
     end
   end

--- a/lib/flight_job/commands/list_job_results.rb
+++ b/lib/flight_job/commands/list_job_results.rb
@@ -76,7 +76,7 @@ module FlightJob
 
       def ls_options
         @ls_options ||= begin
-          base = []
+          base = ['-v']
           base << '-lAR' if opts.verbose
           base << '--color' if $stdout.tty?
           [*base, *user_ls_options ]

--- a/lib/flight_job/commands/submit_job.rb
+++ b/lib/flight_job/commands/submit_job.rb
@@ -38,7 +38,7 @@ module FlightJob
         # Patches the submit flag on to output_options
         # NOTE: There is probably a better way to do this in general,
         #       but this is a once off
-        output_options.merge!(submit: true)
+        output_options.merge!(submit: job.metadata['submit_status'] != 0)
 
         puts render_output(Outputs::InfoJob, job.decorate)
       end

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -87,7 +87,7 @@ module FlightJob
               default: ->(config) { File.join("usr/share/job/adapter.#{config.scheduler}.erb") },
               transform: relative_to(root_path)
 
-    attribute :submission_period, default: 3600
+    attribute :submission_period, default: 300
     validates :submission_period, numericality: { only_integers: true }
 
     attribute :minimum_terminal_width, default: 80

--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -67,7 +67,7 @@ module FlightJob
           elsif object.metadata['cancelled']
             'CANCELLED'
           elsif object.metadata['lazy']
-            'HOLD'
+            'WAITING'
           elsif states == ['COMPLETED']
             'COMPLETED'
           else

--- a/lib/flight_job/job_transitions/bootstrap_monitor.rb
+++ b/lib/flight_job/job_transitions/bootstrap_monitor.rb
@@ -58,9 +58,9 @@ module FlightJob
           validate_data(SUBMITTER_SCHEMA, data, tag: 'submit')
         rescue CommandError
           # The command lied about exiting 0! It did not report the json payload
-          # correctly. Changing the status to 126
+          # correctly. Changing the status to 128
           job.metadata['job_type'] = 'FAILED_SUBMISSION'
-          job.metadata['submit_status'] = 126
+          job.metadata['submit_status'] = 128
           job.metadata["submit_stderr"] << <<~MSG.chomp
             Failed to parse JSON response after the command original exited 0!
           MSG

--- a/lib/flight_job/job_transitions/failed_submitter.rb
+++ b/lib/flight_job/job_transitions/failed_submitter.rb
@@ -46,7 +46,7 @@ module FlightJob
             The following job is being flagged as FAILED as it has not been submitted: #{job.id}
           ERROR
           job.metadata['job_type'] = "FAILED_SUBMISSION"
-          job.metadata['submit_status'] = 126
+          job.metadata['submit_status'] = 128
           job.metadata['submit_stdout'] = ''
           job.metadata['submit_stderr'] = 'Failed to run the submission command for an unknown reason'
           job.save_metadata


### PR DESCRIPTION
This PR contains assorted small changes

Currently based on #56 , please merge it first

---

This PR makes the following changes:

* The default timeout period is now 5mins
* The `HOLD` state has been renamed `WAITING`,
* The task's are now sorted numerically,
* Changes the failed submission status from 126 to 128,
* Suppress stdout/stderr on `submit-job` when it exits 0