### PR TITLE
Save the jobs after they have been submitted

### DIFF
--- a/config/schemas/job/version1.json
+++ b/config/schemas/job/version1.json
@@ -27,6 +27,7 @@
     "job_type": {
       "enum": [
         "INITIALIZING",
+        "MONITORING",
         "SINGLETON",
         "ARRAY",
         "FAILED_SUBMISSION"
@@ -102,6 +103,61 @@
         "version": {
           "const": 1
         },
+        "submit_status": {
+          "const": 0
+        },
+        "submit_stdout": {
+          "type": "string"
+        },
+        "submit_stderr": {
+          "type": "string"
+        },
+        "results_dir": {
+          "type": "string",
+          "minLength": 1
+        },
+        "job_type": {
+          "const": "MONITORING"
+        }
+      }
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "required": [
+            "created_at",
+            "job_type",
+            "rendered_path",
+            "script_id",
+            "version"
+          ]
+        },
+        {
+          "required": [
+            "submit_status",
+            "submit_stdout",
+            "submit_stderr"
+          ]
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "rendered_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "script_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "const": 1
+        },
         "job_type": {
           "const": "FAILED_SUBMISSION"
         },
@@ -135,7 +191,11 @@
           "required": [
             "submit_status",
             "submit_stdout",
-            "submit_stderr",
+            "submit_stderr"
+          ]
+        },
+        {
+          "required": [
             "scheduler_id"
           ]
         },
@@ -171,11 +231,11 @@
         "submit_stderr": {
           "type": "string"
         },
-        "scheduler_id": {
+        "results_dir": {
           "type": "string",
           "minLength": 1
         },
-        "results_dir": {
+        "scheduler_id": {
           "type": "string",
           "minLength": 1
         },
@@ -253,7 +313,11 @@
           "required": [
             "submit_status",
             "submit_stdout",
-            "submit_stderr",
+            "submit_stderr"
+          ]
+        },
+        {
+          "required": [
             "scheduler_id"
           ]
         },
@@ -288,11 +352,11 @@
         "submit_stderr": {
           "type": "string"
         },
-        "scheduler_id": {
+        "results_dir": {
           "type": "string",
           "minLength": 1
         },
-        "results_dir": {
+        "scheduler_id": {
           "type": "string",
           "minLength": 1
         },

--- a/config/schemas/job/version1.json
+++ b/config/schemas/job/version1.json
@@ -26,7 +26,7 @@
     },
     "job_type": {
       "enum": [
-        "INITIALIZING",
+        "SUBMITTING",
         "MONITORING",
         "SINGLETON",
         "ARRAY",
@@ -62,7 +62,7 @@
           "const": 1
         },
         "job_type": {
-          "const": "INITIALIZING"
+          "const": "SUBMITTING"
         }
       }
     },

--- a/config/schemas/job/version1.json
+++ b/config/schemas/job/version1.json
@@ -27,7 +27,7 @@
     "job_type": {
       "enum": [
         "SUBMITTING",
-        "MONITORING",
+        "BOOTSTRAPPING",
         "SINGLETON",
         "ARRAY",
         "FAILED_SUBMISSION"
@@ -117,7 +117,7 @@
           "minLength": 1
         },
         "job_type": {
-          "const": "MONITORING"
+          "const": "BOOTSTRAPPING"
         }
       }
     },

--- a/config/schemas/job/version1.template.yaml
+++ b/config/schemas/job/version1.template.yaml
@@ -12,13 +12,16 @@ __meta__:
     version:
       <<: *VERSION
   SUBMITTED_REQUIRED: &SUBMITTED_REQUIRED
-    required: ['submit_status', 'submit_stdout', 'submit_stderr', 'scheduler_id']
+    required: ['submit_status', 'submit_stdout', 'submit_stderr']
   SUBMITTED_PROPERTIES: &SUBMITTED_PROPERTIES
     submit_status: { const: 0 }
     submit_stdout: { "type" : "string" }
     submit_stderr: { "type" : "string" }
-    scheduler_id: { "type" : "string", "minLength" : 1 }
     results_dir: { "type" : "string", "minLength" : 1 }
+  SCHED_ID_REQUIRED: &SCHED_ID_REQUIRED
+    required: ["scheduler_id"]
+  SCHED_ID_PROPERTIES: &SCHED_ID_PROPERTIES
+    scheduler_id: { "type" : "string", "minLength" : 1 }
   STATES_ENUM: &STATES_ENUM
     enum: ["PENDING", "RUNNING", "FAILED", "COMPLETED", "CANCELLED", "UNKNOWN"]
 
@@ -28,15 +31,29 @@ additionalProperties: true
 properties:
   <<: *SHARED_PROPERTIES
   job_type:
-    enum: ["INITIALIZING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
+    enum: ["INITIALIZING", "MONITORING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
 oneOf:
   # INITIALIZING Jobs
+  # NOTE: All jobs are created in the state before submit.sh is ran
   - type: "object"
     additionalProperties: false
     <<: *SHARED_REQUIRED
     properties:
       <<: *SHARED_PROPERTIES
       job_type: { "const" : "INITIALIZING" }
+
+  # MONITORING Jobs
+  # NOTE: This represents jobs which where succesfully submitted but have
+  # not been monitored for the first time
+  - type: "object"
+    additionalProperties: false
+    allOf:
+      - *SHARED_REQUIRED
+      - *SUBMITTED_REQUIRED
+    properties:
+      <<: *SHARED_PROPERTIES
+      <<: *SUBMITTED_PROPERTIES
+      job_type: { "const" : "MONITORING" }
 
   # FAILED_SUBMISSION Jobs
   - type: "object"
@@ -57,11 +74,13 @@ oneOf:
     allOf:
       - *SHARED_REQUIRED
       - *SUBMITTED_REQUIRED
+      - *SCHED_ID_REQUIRED
       - required: ['state', 'scheduler_state']
     properties:
       # Required
       <<: *SHARED_PROPERTIES
       <<: *SUBMITTED_PROPERTIES
+      <<: *SCHED_ID_PROPERTIES
       job_type: { "const" : "SINGLETON" }
       state: *STATES_ENUM
       scheduler_state: { "type" : "string", "minLength" : 1 }
@@ -87,11 +106,13 @@ oneOf:
     allOf:
       - *SHARED_REQUIRED
       - *SUBMITTED_REQUIRED
+      - *SCHED_ID_REQUIRED
       - required: ['lazy']
     properties:
       # Required
       <<: *SHARED_PROPERTIES
       <<: *SUBMITTED_PROPERTIES
+      <<: *SCHED_ID_PROPERTIES
       job_type: { "const" : "ARRAY" }
       lazy: { "type" : "boolean" }
       cancelled: { "type" : "boolean" }

--- a/config/schemas/job/version1.template.yaml
+++ b/config/schemas/job/version1.template.yaml
@@ -31,16 +31,17 @@ additionalProperties: true
 properties:
   <<: *SHARED_PROPERTIES
   job_type:
-    enum: ["INITIALIZING", "MONITORING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
+    enum: ["SUBMITTING", "MONITORING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
+
 oneOf:
-  # INITIALIZING Jobs
+  # SUBMITTING Jobs
   # NOTE: All jobs are created in the state before submit.sh is ran
   - type: "object"
     additionalProperties: false
     <<: *SHARED_REQUIRED
     properties:
       <<: *SHARED_PROPERTIES
-      job_type: { "const" : "INITIALIZING" }
+      job_type: { "const" : "SUBMITTING" }
 
   # MONITORING Jobs
   # NOTE: This represents jobs which where succesfully submitted but have

--- a/config/schemas/job/version1.template.yaml
+++ b/config/schemas/job/version1.template.yaml
@@ -31,7 +31,7 @@ additionalProperties: true
 properties:
   <<: *SHARED_PROPERTIES
   job_type:
-    enum: ["SUBMITTING", "MONITORING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
+    enum: ["SUBMITTING", "BOOTSTRAPPING", "SINGLETON", "ARRAY", "FAILED_SUBMISSION"]
 
 oneOf:
   # SUBMITTING Jobs
@@ -43,7 +43,7 @@ oneOf:
       <<: *SHARED_PROPERTIES
       job_type: { "const" : "SUBMITTING" }
 
-  # MONITORING Jobs
+  # BOOTSTRAPPING Jobs
   # NOTE: This represents jobs which where succesfully submitted but have
   # not been monitored for the first time
   - type: "object"
@@ -54,7 +54,7 @@ oneOf:
     properties:
       <<: *SHARED_PROPERTIES
       <<: *SUBMITTED_PROPERTIES
-      job_type: { "const" : "MONITORING" }
+      job_type: { "const" : "BOOTSTRAPPING" }
 
   # FAILED_SUBMISSION Jobs
   - type: "object"

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -253,8 +253,9 @@ module FlightJob
           end
           raise InternalError, "Unexpectedly failed to load job: #{id}"
         end
-        job.monitor
-        unless job.submitted?
+        initializing = job.initializing?
+        monitored = job.monitor
+        if initializing && !monitored
           raise MissingJobError, "Could not load initializing job: #{id}"
         end
       end

--- a/lib/flight_job/commands/submit_job.rb
+++ b/lib/flight_job/commands/submit_job.rb
@@ -38,13 +38,9 @@ module FlightJob
         # Patches the submit flag on to output_options
         # NOTE: There is probably a better way to do this in general,
         #       but this is a once off
-        show_submit = !job.submitted?
-        output_options.merge!(submit: show_submit)
+        output_options.merge!(submit: true)
 
         puts render_output(Outputs::InfoJob, job.decorate)
-        unless job.submitted?
-          raise GeneralError, "The job submission failed!"
-        end
       end
 
       def script

--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -40,8 +40,8 @@ module FlightJob
 
       def initialize(object)
         @object = object
-        if object.job_type == 'INITIALIZING'
-          raise InternalError, "Can not decorate an INITIALIZING job"
+        if object.job_type == 'SUBMITTING'
+          raise InternalError, "Can not decorate an SUBMITTING job"
         end
       end
 

--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -40,8 +40,8 @@ module FlightJob
 
       def initialize(object)
         @object = object
-        if object.job_type == 'SUBMITTING'
-          raise InternalError, "Can not decorate an SUBMITTING job"
+        if object.initializing?
+          raise InternalError, "Can not decorate job #{object.job_type}"
         end
       end
 

--- a/lib/flight_job/job_transitions/bootstrap_monitor.rb
+++ b/lib/flight_job/job_transitions/bootstrap_monitor.rb
@@ -1,0 +1,89 @@
+#==============================================================================
+# Copyright (C) 2021-present Alces Flight Ltd.
+#
+# This file is part of Flight Job.
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which is available at
+# <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+# terms made available by Alces Flight Ltd - please direct inquiries
+# about licensing to licensing@alces-flight.com.
+#
+# Flight Job is distributed in the hope that it will be useful, but
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+# IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+# OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+# PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+# details.
+#
+# You should have received a copy of the Eclipse Public License 2.0
+# along with Flight Job. If not, see:
+#
+#  https://opensource.org/licenses/EPL-2.0
+#
+# For more information on Flight Job, please visit:
+# https://github.com/openflighthpc/flight-job
+#==============================================================================
+
+module FlightJob
+  module JobTransitions
+    SUBMITTER_SCHEMA = JSONSchemer.schema({
+      "type" => "object",
+      "additionalProperties" => false,
+      "required" => ["job_type", "version", "id", "results_dir"],
+      "properties" => {
+        "version" => { "const" => 1 },
+        "id" => { "type" => "string", "minLength" => 1 },
+        "results_dir" => { "type" => "string", "minLength" => 1 },
+        "job_type" => { "enum" => ["SINGLETON", "ARRAY"] }
+      }
+    })
+
+    BootstrapMonitor = Struct.new(:job) do
+      include JobTransitionHelper
+
+      def run
+        run!
+        return true
+      rescue
+        Flight.logger.error "Failed to boostrap monitor job '#{job.id}'"
+        Flight.logger.warn $!
+        return false
+      end
+
+      def run!
+        # Attempt to parse the stdout for the data
+        begin
+          data = parse_stdout_json(job.metadata['submit_stdout'], tag: 'submit')
+          validate_data(SUBMITTER_SCHEMA, data, tag: 'submit')
+        rescue CommandError
+          # The command lied about exiting 0! It did not report the json payload
+          # correctly. Changing the status to 126
+          job.metadata['job_type'] = 'FAILED_SUBMISSION'
+          job.metadata['submit_status'] = 126
+          job.metadata["submit_stderr"] << <<~MSG.chomp
+            Failed to parse JSON response after the command original exited 0!
+          MSG
+          job.save_metadata
+          raise $!
+        end
+
+        # The job was submitted correctly and is now pending
+        job.metadata['results_dir'] = data['results_dir']
+        job.metadata['scheduler_id'] = data['id']
+        job.metadata['job_type'] = data['job_type']
+
+        # Run the monitor
+        case data['job_type']
+        when 'SINGLETON'
+          job.metadata['state'] = 'PENDING'
+          SingletonMonitor.new(job).run!
+        when 'ARRAY'
+          job.metadata['cancelled'] = false
+          job.metadata['lazy'] = true
+          ArrayMonitor.new(job).run!
+        end
+      end
+    end
+  end
+end

--- a/lib/flight_job/job_transitions/failed_submitter.rb
+++ b/lib/flight_job/job_transitions/failed_submitter.rb
@@ -46,7 +46,7 @@ module FlightJob
             The following job is being flagged as FAILED as it has not been submitted: #{job.id}
           ERROR
           job.metadata['job_type'] = "FAILED_SUBMISSION"
-          job.metadata['submit_status'] = 128
+          job.metadata['submit_status'] = 126
           job.metadata['submit_stdout'] = ''
           job.metadata['submit_stderr'] = 'Failed to run the submission command for an unknown reason'
           job.save_metadata

--- a/lib/flight_job/job_transitions/job_transition_helper.rb
+++ b/lib/flight_job/job_transitions/job_transition_helper.rb
@@ -30,6 +30,15 @@ require 'open3'
 module FlightJob
   module JobTransitions
     module JobTransitionHelper
+      # TODO: Remove me!
+      def method_missing(s, *args)
+        if respond_to? :job
+          job.send(s, *args)
+        else
+          __getobj__.send(s, *args)
+        end
+      end
+
       def execute_command(*cmd, tag:)
         # NOTE: Should the PATH be configurable instead of inherited from the environment?
         # This could lead to differences when executed via the CLI or the webapp

--- a/lib/flight_job/job_transitions/job_transition_helper.rb
+++ b/lib/flight_job/job_transitions/job_transition_helper.rb
@@ -62,13 +62,8 @@ module FlightJob
 
         data = nil
         if status.success?
-          begin
-            data = JSON.parse(cmd_stdout.split("\n").last.to_s)
-          rescue JSON::ParserError
-            FlightJob.logger.error("Failed to parse #{tag} JSON for job: #{id}")
-            FlightJob.logger.debug($!.message)
-            raise_command_error
-          end
+          # TODO: Remove this, bad JSON needs to be handled higher up
+          data = parse_stdout_json(cmd_stdout, tag: tag)
         end
 
         yield(status, cmd_stdout, cmd_stderr, data)

--- a/lib/flight_job/job_transitions/submitter.rb
+++ b/lib/flight_job/job_transitions/submitter.rb
@@ -85,8 +85,8 @@ module FlightJob
             return
           end
 
-          # Save the job into the monitoring state
-          job.metadata["job_type"] = "MONITORING"
+          # Save the job into the bootstrapping state.
+          job.metadata["job_type"] = "BOOTSTRAPPING"
           job.save_metadata
 
           # Bootstrap the monitor

--- a/lib/flight_job/job_transitions/submitter.rb
+++ b/lib/flight_job/job_transitions/submitter.rb
@@ -27,18 +27,6 @@
 
 module FlightJob
   module JobTransitions
-    SUBMITTER_SCHEMA = JSONSchemer.schema({
-      "type" => "object",
-      "additionalProperties" => false,
-      "required" => ["job_type", "version", "id", "results_dir"],
-      "properties" => {
-        "version" => { "const" => 1 },
-        "id" => { "type" => "string", "minLength" => 1 },
-        "results_dir" => { "type" => "string", "minLength" => 1 },
-        "job_type" => { "enum" => ["SINGLETON", "ARRAY"] }
-      }
-    })
-
     Submitter = Struct.new(:job) do
       include JobTransitionHelper
       include ActiveModel::Validations
@@ -97,34 +85,12 @@ module FlightJob
             return
           end
 
-          # Validate the payload format
-          begin
-            validate_data(SUBMITTER_SCHEMA, data, tag: 'submit')
-          rescue CommandError
-            # The command lied about exiting 0! It did not report the json payload
-            # correctly. Changing the status to 126
-            job.metadata['job_type'] = 'FAILED_SUBMISSION'
-            job.metadata['submit_status'] = 126
-            job.metadata["submit_stderr"] << "\nFailed to parse JSON response"
-            job.save_metadata
-            raise $!
-          end
+          # Save the job into the monitoring state
+          job.metadata["job_type"] = "MONITORING"
+          job.save_metadata
 
-          # The job was submitted correctly and is now pending
-          job.metadata['results_dir'] = data['results_dir']
-          job.metadata['scheduler_id'] = data['id']
-          job.metadata['job_type'] = data['job_type']
-
-          # Run the monitor
-          case data['job_type']
-          when 'SINGLETON'
-            job.metadata['state'] = 'PENDING'
-            SingletonMonitor.new(job).run!
-          when 'ARRAY'
-            job.metadata['cancelled'] = false
-            job.metadata['lazy'] = true
-            ArrayMonitor.new(job).run!
-          end
+          # Bootstrap the monitor
+          BootstrapMonitor.new(job).run!
         end
       end
     end

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -293,6 +293,7 @@ module FlightJob
       unless success
         @metadata = original_metadata
       end
+      success
     end
 
     def cancel

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -246,7 +246,7 @@ module FlightJob
     end
 
     def initializing?
-      ['SUBMITTING', 'MONITORING'].include? job_type
+      ['SUBMITTING', 'BOOTSTARPPING'].include? job_type
     end
 
     def scheduler_id
@@ -283,7 +283,7 @@ module FlightJob
       success = case job_type
       when 'SUBMITTING'
         JobTransitions::FailedSubmitter.new(self).run
-      when 'MONITORING'
+      when 'BOOTSTARPPING'
         JobTransitions::BootstrapMonitor.new(self).run
       when 'SINGLETON'
         JobTransitions::SingletonMonitor.new(self).run

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -63,8 +63,8 @@ module FlightJob
         job = new(id: id)
         if job.valid?(:load)
           job.tap(&:monitor)
-          if job.job_type == 'INITIALIZING'
-            FlightJob.logger.debug("Skipping initializing job: #{job.id}")
+          if job.initializing?
+            FlightJob.logger.debug("Skipping #{job.job_type} job: #{job.id}")
             nil
           else
             job
@@ -114,7 +114,7 @@ module FlightJob
       # Initialize the job with the script
       if metadata.empty?
         metadata["created_at"] = Time.now.rfc3339
-        metadata["job_type"] = "INITIALIZING"
+        metadata["job_type"] = "SUBMITTING"
         metadata["rendered_path"] = File.join(job_dir, script.script_name)
         metadata["script_id"] = script.id
         metadata["version"] = SCHEMA_VERSION
@@ -196,7 +196,7 @@ module FlightJob
     def state
       Flight.logger.warn "DEPRECATED: Job#state does not function correctly for array tasks"
       case job_type
-      when 'INITIALIZING'
+      when 'SUBMITTING'
         'PENDING'
       when 'FAILED_SUBMISSION'
         'FAILED'
@@ -245,8 +245,8 @@ module FlightJob
       end
     end
 
-    def submitted?
-      job_type != 'INITIALIZING'
+    def initializing?
+      ['SUBMITTING', 'MONITORING'].include? job_type
     end
 
     def scheduler_id
@@ -380,7 +380,7 @@ module FlightJob
                   "for '#{id}' as it is an individual job."
                 when 'ARRAY'
                   "for '#{id}' as it is an array job."
-                when 'INITIALIZING'
+                when 'SUBMITTING'
                   "for job '#{id}' as it is pending submission."
                 when 'FAILED_SUBMISSION'
                   "for job '#{id}' as it did not succesfully submit."

--- a/lib/flight_job/models/job.rb
+++ b/lib/flight_job/models/job.rb
@@ -158,7 +158,7 @@ module FlightJob
       else
         @metadata = {
           "created_at" => Time.now.rfc3339,
-          "job_type" => "INITIALIZING",
+          "job_type" => "SUBMITTING",
           "script_id" => script.id,
           "rendered_path" => File.join(job_dir, script.script_name),
           "version" => SCHEMA_VERSION,

--- a/lib/flight_job_migration/jobs/v1.rb
+++ b/lib/flight_job_migration/jobs/v1.rb
@@ -42,9 +42,9 @@ module FlightJobMigration
     SCHEMA_V1_RAW = JSON.parse(
       File.read Flight.config.join_schema_path("version1.json")
     )
-    SCHEMA_V1_INITIALIZING = JSONSchemer.schema(
+    SCHEMA_V1_SUBMITTING = JSONSchemer.schema(
       SCHEMA_V1_RAW["oneOf"].find do |schema|
-        schema["properties"]["job_type"]["const"] == "INITIALIZING"
+        schema["properties"]["job_type"]["const"] == "SUBMITTING"
       end
     )
     SCHEMA_V1_SINGLETON = JSONSchemer.schema(
@@ -122,8 +122,8 @@ module FlightJobMigration
         schema = case metadata["job_type"]
                  when 'SINGLETON'
                    SCHEMA_V1_SINGLETON
-                 when 'INITIALIZING'
-                   SCHEMA_V1_INITIALIZING
+                 when 'SUBMITTING'
+                   SCHEMA_V1_SUBMITTING
                  else
                    SCHEMA_V1_FAILED_SUBMISSION
                  end
@@ -175,7 +175,7 @@ module FlightJobMigration
       def migrate_initializing
         validate_initial
         metadata["version"] = 1
-        metadata["job_type"] = "INITIALIZING"
+        metadata["job_type"] = "SUBMITTING"
         metadata.merge! initial.slice("created_at", "script_id")
         metadata["rendered_path"] = generate_rendered_path
         validate_metadata


### PR DESCRIPTION
Previously a job had to be submitted and monitored before being saved. This meant `flight-job` could loose track of submitted jobs.

This fixes the issue by:

* Renames the original `INITIALIZING` to submitting, and
* Saves successfully submitted jobs with the `MONITORING` job type.

A `MONITORING` job means it was successfully submitted but not yet been monitored for the first time. They are hidden from the end user (similar to `SUBMITTING`) to prevent issues with null fields. 