### PR TITLE
Run both `sacct` and `scontrol` for array jobs

### DIFF
--- a/libexec/job/slurm/monitor-array.sh
+++ b/libexec/job/slurm/monitor-array.sh
@@ -114,7 +114,7 @@ run_scontrol() {
 }
 
 run_sacct() {
-  sacct --noheader --parsable --jobs "$1" --format State,Reason,START,END,AllocTRES,JobID,JobIDRaw
+  sacct --noheader --parsable -X --jobs "$1" --format State,Reason,START,END,AllocTRES,JobID,JobIDRaw
 }
 
 parse_scontrol_output() {
@@ -193,10 +193,8 @@ main() {
     fi
 
     # Second, attempt to load additional data from sacct
-    # NOTE: The earliest tasks may move here before the last finishes
-    # XXX Replace with -X / --allocations
+    # The earliest tasks may move here before the last finishes
     output=$(run_sacct "$JOB_ID" | tee >(log_command "sacct" 1>&2))
-    output=$(echo "$output" | awk 'FNR%2')
     sacct_exit_status=$?
     if [[ $sacct_exit_status -eq 0 ]] && [ -z "$output" ]; then
         echo "No Tasks Found!" >&2

--- a/libexec/job/slurm/monitor-array.sh
+++ b/libexec/job/slurm/monitor-array.sh
@@ -138,10 +138,6 @@ parse_scontrol_output() {
           # New tasks could still be created.
           ARRAY_JOB[lazy]="true"
         fi
-  
-        if [ "$(parse_job_id <<< "${line}")" == "${JOB_ID}" ] ; then
-            ARRAY_JOB[state]=$(parse_state <<< "${line}")
-        fi
     done
 
     ARRAY_JOB[tasks]="$tasks"
@@ -152,18 +148,22 @@ parse_sacct_output() {
     declare -A TASK
     local tasks
 
-    tasks='{}'
+    tasks="${ARRAY_JOB[tasks]}"
+    if [ -z "$tasks" ]; then
+      tasks="{}"
+    fi
 
     while IFS= read -r line; do
-        unset TASK
-        declare -A TASK
         index=$(parse_task_index <<< "$line")
-        parse_task <<< "${line}"
-        # declare -p TASK >&2
-        tasks="$(json_object_insert "$tasks" "$index" "$(generate_task_json)")"
+        existing_task=$(printf "$tasks" | jq ".[\"$index\"]")
+        numeric_id=$(echo "${index}" | grep -P '^\d+$')
 
-        if [ "$(parse_job_id <<< "$line")" == "${JOB_ID}" ] ; then
-            ARRAY_JOB[state]=$(parse_state <<< "$line")
+        if [ "$existing_task" == "null" ] && [ -n "$numeric_id" ]; then
+          unset TASK
+          declare -A TASK
+          parse_task <<< "${line}"
+          # declare -p TASK >&2
+          tasks="$(json_object_insert "$tasks" "$index" "$(generate_task_json)")"
         fi
     done
 
@@ -178,35 +178,36 @@ main() {
     assert_progs jq scontrol sacct
 
     ARRAY_JOB[lazy]="false"
-    ARRAY_JOB[state]="UNKNOWN"
 
+    # First attempt to get the data from scontrol
     output=$(run_scontrol "${JOB_ID}" | tee >(log_command "scontrol" 1>&2))
-    exit_status=$?
-
-    if [[ $exit_status -eq 0 ]] ; then
+    scontrol_exit_status=$?
+    if [[ $scontrol_exit_status -eq 0 ]] ; then
         source_parsers "scontrol"
         parse_scontrol_output <<< "$output"
-    elif [[ "${output}" == "slurm_load_jobs error: Invalid job id specified" ]] ; then
-        output=$(run_sacct "$JOB_ID" | tee >(log_command "sacct" 1>&2))
-        exit_status=$?
-        # XXX Replace with -X / --allocations
-        output=$(echo "$output" | awk 'FNR%2')
-        if [[ $exit_status -eq 0 ]] && [ -z "$output" ]; then
-            echo "No Tasks Found!" >&2
-        elif [[ $exit_status -eq 0 ]]; then
-            source_parsers "sacct"
-            parse_sacct_output <<< "${output}"
-        else
-            exit $exit_status
-        fi
-    else
-        exit $exit_status
+    fi
+
+    # Second, attempt to load additional data from sacct
+    # NOTE: The earliest tasks may move here before the last finishes
+    # XXX Replace with -X / --allocations
+    output=$(run_sacct "$JOB_ID" | tee >(log_command "sacct" 1>&2))
+    output=$(echo "$output" | awk 'FNR%2')
+    sacct_exit_status=$?
+    if [[ $sacct_exit_status -eq 0 ]] && [ -z "$output" ]; then
+        echo "No Tasks Found!" >&2
+    elif [[ $sacct_exit_status -eq 0 ]]; then
+        source_parsers "sacct"
+        parse_sacct_output <<< "${output}"
+    fi
+
+    # Exit if both commands failed
+    if [ $scontrol_exit_status -ne 0 ] && [ $sacct_exit_status -ne 0 ]; then
+        exit $sacct_exit_status
     fi
 
     if [ "${ARRAY_JOB[state]}" == "CANCELLED" ] ; then
         ARRAY_JOB[lazy]="false"
     fi
-    # declare -p ARRAY_JOB >&2
 
     generate_template | report_metadata
 }


### PR DESCRIPTION
Based on #57

For sufficiently long running array jobs, the first task(s) may drop out of `scontrol` before the last tasks finishes. This can cause jobs to get stuck in a `RUNNING` state as the initial tasks cannot be updated. This will rectify itself when the entire job moves to `sacct`.

Instead, the `monitor-array.sh` runs both `scontrol` and `sacct` and merges the tasks list.