### PR TITLE
Ensure `QuestionPrompter` never ignores answers

### DIFF
--- a/lib/flight_job/commands/create_script.rb
+++ b/lib/flight_job/commands/create_script.rb
@@ -83,7 +83,7 @@ module FlightJob
             # We're missing something.  It could be the answers, the notes, or
             # the script_id.  Either way, stdin is not used and stdout is a
             # TTY, so we can prompt for what's missing.
-            run_question_prompter(script_id, notes || "")
+            run_question_prompter(script_id, answers || {}, notes || "")
 
           else
             # We may or may not have answers, a script_id or notes.  We use
@@ -101,32 +101,16 @@ module FlightJob
 
       private
 
-      def run_question_prompter(script_id, notes)
-        # XXX BUG ALERT.  Creating the script via the question prompter has
-        # the following bug.
-        #
-        # If the user provides questions, the question prompter does not
-        # automatically ask any questions.  It displays a summary and gives
-        # the user the option to answer the questions.  However, it uses the
-        # default answers not those provided by the user.
-        #
-        # Once the QuestionPrompter has completed, we use the answers it has,
-        # not those provided by the user.
-        #
-        # This effectively requires the user to provide the answers twice. For
-        # this particular code path.
-        #
-        # The fix is to populate QuestionPrompter with the given answers.
+      def run_question_prompter(script_id, answers, notes)
         prompter = QuestionPrompter.new(
           pastel,
           pager,
           template.generation_questions,
-          notes,
-          script_id
+          script_id,
+          answers,
+          notes
         )
-        prompter.prompt_invalid_id
-        prompter.prompt_all unless answers_provided?
-        prompter.prompt_loop
+        prompter.call
         create_script(prompter.id, prompter.answers, prompter.notes)
       end
 

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -90,14 +90,14 @@ module FlightJob
 
     attr_accessor :id, :answers, :notes
 
-    def initialize(pastel, pager, questions, notes, id)
+    def initialize(pastel, pager, questions, id, answers, notes)
       @pastel = pastel
       @pager = pager
       @questions = questions
       @notes = notes
       @id = id
 
-      @answers = {}
+      @answers = answers || {}
 
       if @id
         @prompt_for_id = false
@@ -107,6 +107,16 @@ module FlightJob
       end
       @prompt_for_notes = true
     end
+
+    def call
+      prompt_invalid_id
+      prompt_all if answers.empty?
+      prompt_loop
+    end
+
+    private
+
+    attr_reader :pastel, :pager, :questions
 
     def prompt_loop
       reask = true
@@ -161,10 +171,6 @@ module FlightJob
       @prompt_for_id = true
       @id = Script.new.id
     end
-
-    private
-
-    attr_reader :pastel, :pager, :questions
 
     def prompt_id
       opts = id ? { default: id } : { required: true }


### PR DESCRIPTION
Previously, if a user provided answers with the `--answers` flag and FSR, the `QuestionPrompter` need to be ran, the answers would be discarded.  The `QuestionPrompter` would show a summary of the default answers, and the default answers would be used in the creation of the script.

Now, the answers provided with `--answers` are not discarded.  The `QuestionPrompter` uses them in the summary and they are used in the creation of the script.