### PR TITLE
Config for extra paths for scheduler scripts

### DIFF
--- a/etc/job.yaml
+++ b/etc/job.yaml
@@ -72,6 +72,26 @@
 # scheduler: slurm
 
 # ==============================================================================
+# Additional PATH directories
+#
+# Additional directories to add to PATH when running the HPC scheduler
+# integratation scripts.
+#
+# If the binaries for your HPC scheduler are installed to non-common
+# directories you will need to modify this setting to include those
+# directories.  The format is the same as the PATH environment variable.
+# E.g., the following setting would add the two directories /opt/tools/bin and
+# /opt/utilities/bin to PATH.
+#
+#   additional_paths: /opt/tools/bin:/opt/utilities/bin
+#
+# The paths must be absolute.
+#
+# The environment variable flight_JOB_addtional_paths takes precedence
+# ==============================================================================
+# additional_paths:
+
+# ==============================================================================
 # Submit Script Path
 # Specify the path to the script which submits jobs.
 #

--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -29,7 +29,6 @@ require 'ostruct'
 require 'pastel'
 require 'tty-editor'
 
-require 'open3'
 require 'stringio'
 
 module FlightJob

--- a/lib/flight_job/commands/submit_job.rb
+++ b/lib/flight_job/commands/submit_job.rb
@@ -25,8 +25,6 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 
-require 'open3'
-
 module FlightJob
   module Commands
     class SubmitJob < Command

--- a/lib/flight_job/configuration.rb
+++ b/lib/flight_job/configuration.rb
@@ -63,6 +63,9 @@ module FlightJob
     attribute :scheduler, default: 'slurm'
     validates :scheduler, presence: true
 
+    attribute :additional_paths, default: '',
+              transform: ->(paths) { paths.empty? || paths[0] == ':' ? paths : ":#{paths}" }
+
     attribute :submit_script_path,
               default: ->(config) { File.join('libexec/job', config.scheduler, 'submit.sh') },
               transform: relative_to(root_path)

--- a/lib/flight_job/job_transitions/canceller.rb
+++ b/lib/flight_job/job_transitions/canceller.rb
@@ -25,6 +25,8 @@
 # https://github.com/openflighthpc/flight-job
 #==============================================================================
 
+require 'open3'
+
 module FlightJob
   module JobTransitions
     class Canceller
@@ -69,7 +71,9 @@ module FlightJob
       private
 
       def execute_command(*cmd, tag:)
-        env = ENV.slice('PATH', 'HOME', 'USER', 'LOGNAME')
+        env = ENV.slice('PATH', 'HOME', 'USER', 'LOGNAME').tap do |h|
+          h['PATH'] += Flight.config.additional_paths
+        end
         cmd_stdout, cmd_stderr, status = Open3.capture3(env, *cmd, unsetenv_others: true, close_others: true)
 
         unless status.success?

--- a/lib/flight_job/job_transitions/job_transition_helper.rb
+++ b/lib/flight_job/job_transitions/job_transition_helper.rb
@@ -40,11 +40,9 @@ module FlightJob
       end
 
       def execute_command(*cmd, tag:)
-        # XXX Should the PATH be configurable instead of inherited from the
-        # environment?  This could lead to differences when executed via the
-        # CLI or the webapp
         env = ENV.slice('PATH', 'HOME', 'USER', 'LOGNAME').tap do |h|
           h['CONTROLS_DIR'] = job.controls_dir.path
+          h['PATH'] += Flight.config.additional_paths
         end
         cmd_stdout, cmd_stderr, status = Open3.capture3(env, *cmd, unsetenv_others: true, close_others: true)
 


### PR DESCRIPTION
There is now a configuration item `additional_paths` that adds the given paths to `PATH` when the HPC scheduler integration scripts are ran. This can be used to provide access to the HPC scheduler binaries and to utilities such as `jq`.