### PR TITLE
Don't blank environment in interactive sessions

### DIFF
--- a/usr/share/job/adapter.slurm.erb
+++ b/usr/share/job/adapter.slurm.erb
@@ -59,6 +59,7 @@ session_start() {
         ${flight_ROOT:-/opt/flight}/bin/flight desktop \
             start \
             --script ${SESSION_SCRIPT} \
+            --no-env-override \
             | tee >( grep '^Identity' | cut -f2 > "${FLIGHT_SESSION_ID_PATH}" )
     )
 

--- a/usr/share/job/adapter.slurm.erb
+++ b/usr/share/job/adapter.slurm.erb
@@ -59,7 +59,7 @@ session_start() {
         ${flight_ROOT:-/opt/flight}/bin/flight desktop \
             start \
             --script ${SESSION_SCRIPT} \
-            --no-env-override \
+            --no-override-env \
             | tee >( grep '^Identity' | cut -f2 > "${FLIGHT_SESSION_ID_PATH}" )
     )
 


### PR DESCRIPTION
This PR amends the `flight desktop start` call when starting an interactive session, calling a CLI parameter introduced to `desktop` in [this PR](https://github.com/openflighthpc/flight-desktop/pull/40) which prevents the session environment from being blanked, and allows the host environment to persist.