### PR TITLE
Fix listing scripts when template is unknown

### DIFF
--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -488,14 +488,14 @@ module FlightJob
     # This allows it to be directly passed to the API layer.
     # Consider refactoring when introducing a non-backwards compatible change
     def metadata
-      return @metadata unless @metadata.nil?
+      return @metadata if defined?(@metadata)
       @metadata = YAML.load(File.read(metadata_path)).to_h
     rescue Errno::ENOENT
       errors.add(:metadata, "has not been saved")
-      @metadata = false
+      @metadata = {}
     rescue Psych::SyntaxError
       errors.add(:metadata, "is not valid YAML")
-      @metadata = false
+      @metadata = {}
     end
 
     def serializable_hash(opts = nil)


### PR DESCRIPTION
Previously, there was an issue where listing scripts could fail if the template was not known.

The exact command that caused this was `flight_JOB_includes=template flight job list-scripts --json`.  Which is the command that the API runs.

This is fixed by ensuring that `Template#metadata` always returns a hash and never `false`.