### PR TITLE
Show question descriptions when creating a script

### DIFF
--- a/lib/flight_job.rb
+++ b/lib/flight_job.rb
@@ -47,6 +47,7 @@ module FlightJob
   autoload 'OneOfParser', File.expand_path('flight_job/one_of_parser.rb', __dir__)
   autoload 'QuestionPrompter', File.expand_path('flight_job/question_prompter', __dir__)
   autoload :QuestionGenerators, File.expand_path('flight_job/question_generators.rb', __dir__)
+  autoload 'WrapIndentHelper', File.expand_path('flight_job/wrap_indent_helper.rb', __dir__)
 
   module Commands
     Dir.glob(File.expand_path('flight_job/commands/*.rb', __dir__)).each do |path|

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -345,14 +345,18 @@ module FlightJob
             opts[:default] = idx + 1 if opt['value'] == default
             { name: opt['text'], value: opt['value'] }
           end
-          prompt.select(question_label(question), choices, **opts)
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          prompt.select("", choices, **opts)
         when 'multiselect'
           opts = { show_help: :always, echo: false, help: MULTI_HELP, default: [] }
           choices = question.format['options'].each_with_index.map do |opt, idx|
             opts[:default] << idx + 1 if default.is_a?(Array) && default.include?(opt['value'])
             { name: opt['text'], value: opt['value'] }
           end
-          prompt.multi_select(question_label(question), choices, **opts)
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          prompt.multi_select("", choices, **opts)
         when 'time'
           puts pastel.green(question_label(question))
           puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -328,11 +328,15 @@ module FlightJob
       answer =
         case question.format['type']
         when 'text'
-          prompt.ask(question_label(question), default: default)
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          prompt.ask("TEXT > ", default: default)
         when 'multiline_text'
           # NOTE: The 'default' field does not work particularly well for multiline inputs
           # Consider replacing with $EDITOR
-          lines = prompt.multiline(question_label(question))
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          lines = prompt.multiline("TEXT > ")
           lines.empty? ? answers[question.id] : lines.join('')
         when 'select'
           error_on_enum_select = true
@@ -350,7 +354,9 @@ module FlightJob
           end
           prompt.multi_select(question_label(question), choices, **opts)
         when 'time'
-          prompt.ask(question_label(question)) do |q|
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          prompt.ask("TEXT > ") do |q|
             q.default default
             q.validate(/\A24:00|([0-1]\d|2[0-3]):[0-5]\d\Z/, "Times must be in HH:MM format")
           end
@@ -359,7 +365,9 @@ module FlightJob
           # By default, this only allows integers. This behaviour has been replicated here
           #
           # Consider refactoring to allow floating points
-          prompt.ask(question_label(question), convert: :integer, default: default)
+          puts pastel.green(question_label(question))
+          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+          prompt.ask("NUMBER > ", convert: :integer, default: default)
         else
           raise InternalError, "Unexpectedly reached question type: #{question.format['type']}"
         end

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -325,17 +325,19 @@ module FlightJob
       error_on_enum_select = false
 
       default = answers.key?(question.id) ? answers[question.id] : question.default
+
+      # Question labels and descriptions are printed separately
+      # to the TTY prompter
+      puts pastel.green(question_label(question))
+      puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+
       answer =
         case question.format['type']
         when 'text'
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           prompt.ask("TEXT > ", default: default)
         when 'multiline_text'
           # NOTE: The 'default' field does not work particularly well for multiline inputs
           # Consider replacing with $EDITOR
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           lines = prompt.multiline("TEXT > ")
           lines.empty? ? answers[question.id] : lines.join('')
         when 'select'
@@ -345,8 +347,6 @@ module FlightJob
             opts[:default] = idx + 1 if opt['value'] == default
             { name: opt['text'], value: opt['value'] }
           end
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           prompt.select("", choices, **opts)
         when 'multiselect'
           opts = { show_help: :always, echo: false, help: MULTI_HELP, default: [] }
@@ -354,12 +354,8 @@ module FlightJob
             opts[:default] << idx + 1 if default.is_a?(Array) && default.include?(opt['value'])
             { name: opt['text'], value: opt['value'] }
           end
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           prompt.multi_select("", choices, **opts)
         when 'time'
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           prompt.ask("TEXT > ") do |q|
             q.default default
             q.validate(/\A24:00|([0-1]\d|2[0-3]):[0-5]\d\Z/, "Times must be in HH:MM format")
@@ -369,8 +365,6 @@ module FlightJob
           # By default, this only allows integers. This behaviour has been replicated here
           #
           # Consider refactoring to allow floating points
-          puts pastel.green(question_label(question))
-          puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
           prompt.ask("NUMBER > ", convert: :integer, default: default)
         else
           raise InternalError, "Unexpectedly reached question type: #{question.format['type']}"

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -328,8 +328,8 @@ module FlightJob
 
       # Question labels and descriptions are printed separately
       # to the TTY prompter
-      puts pastel.green(question_label(question))
-      puts pastel.dim(WrapIndentHelper.call(question.description, 80, 1)) if question.description
+      puts question_label(question)
+      puts pastel.bright_blue(WrapIndentHelper.call(question.description, 80, 1)) if question.description
 
       answer =
         case question.format['type']

--- a/lib/flight_job/wrap_indent_helper.rb
+++ b/lib/flight_job/wrap_indent_helper.rb
@@ -1,0 +1,54 @@
+#==============================================================================
+## Copyright (C) 2021-present Alces Flight Ltd.
+##
+## This file is part of Flight Job.
+##
+## This program and the accompanying materials are made available under
+## the terms of the Eclipse Public License 2.0 which is available at
+## <https://www.eclipse.org/legal/epl-2.0>, or alternative license
+## terms made available by Alces Flight Ltd - please direct inquiries
+## about licensing to licensing@alces-flight.com.
+##
+## Flight Job is distributed in the hope that it will be useful, but
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+## IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS
+## OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A
+## PARTICULAR PURPOSE. See the Eclipse Public License 2.0 for more
+## details.
+##
+## You should have received a copy of the Eclipse Public License 2.0
+## along with Flight Job. If not, see:
+##
+##  https://opensource.org/licenses/EPL-2.0
+##
+## For more information on Flight Job, please visit:
+## https://github.com/openflighthpc/flight-job
+##==============================================================================
+module FlightJob
+  # The following helper is designed to be used by QuestionPrompter to output
+  # question descriptions with the correct formatting/styling. It was created
+  # when it was judged that questions and their descriptions should be handled
+  # separately from the TTY::Prompt that takes the user's input; this meant that
+  # questions needed a way of being formatted without TTY::Prompt's help.
+  class WrapIndentHelper
+    def self.call(description, max=80, indent_level=0)
+      # - Split string into an array with one line per element,
+      # - Prepend two spaces to the start of each line for each indent level
+      # - Join the lines with a newline character and return the result
+      wrapped_description = split_string(description, max).map do |s|
+        s.prepend("  " * indent_level)
+      end
+
+      return wrapped_description.join("\n")
+    end
+
+    private
+
+    # Regularly express your desire to split the description into lines of no
+    # more than 80 characters, rounding down if the wrap would begin in the
+    # middle of a word.
+    def self.split_string(str, max)
+      return str.scan(/\S.{0,#{max}}\S(?=\s|$)|\S+/)
+    end
+  end
+end


### PR DESCRIPTION
This PR enhances the question prompter used when creating a script. Questions will now be followed by their 'question description' (when it exists in the employed template) when creating a script at the command line. Previously, the descriptions were only used in the webapp.

Due to the formatting requirements for the CLI, a new helper class has been added: `WrapIndentHelper`.

- When passed a string (and optionally, a wrap limit and indentation size), the class will return a multiline string equal to the input string with word-wrapping and indentation at the start of each line.
- The defaults for the wrap limit and indentation size are 80 characters and no indentation.
- When setting indentation, the class will prepend 2 whitespace characters per 'level' asked. For example:

```

2.7.1 :004 > puts FlightJob::WrapIndentHelper.call(input)
Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
Ipsum has been the industry's standard dummy text ever since the 1500s, when an
unknown printer took a galley of type and scrambled it to make a type specimen
book.
 => nil

2.7.1 :005 > puts FlightJob::WrapIndentHelper.call(input, 80, 1)
  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
  Ipsum has been the industry's standard dummy text ever since the 1500s, when an
  unknown printer took a galley of type and scrambled it to make a type specimen
  book.
 => nil

2.7.1 :006 > puts FlightJob::WrapIndentHelper.call(input, 80, 2)
    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem
    Ipsum has been the industry's standard dummy text ever since the 1500s, when an
    unknown printer took a galley of type and scrambled it to make a type specimen
    book.
 => nil
```
