### PR TITLE
Fix issue with dynamic empty file listing

### DIFF
--- a/lib/flight_job/question_generators/file_listing.rb
+++ b/lib/flight_job/question_generators/file_listing.rb
@@ -59,7 +59,11 @@ module FlightJob
         when String
           [ { "text" => @include_null, "value" => nil } ] + paths
         else
-          paths
+          if paths.empty?
+            [ { "text" => "(no matching files found)", "value" => nil } ]
+          else
+            paths
+          end
         end
       end
 

--- a/lib/flight_job/question_prompter.rb
+++ b/lib/flight_job/question_prompter.rb
@@ -354,7 +354,7 @@ module FlightJob
             opts[:default] << idx + 1 if default.is_a?(Array) && default.include?(opt['value'])
             { name: opt['text'], value: opt['value'] }
           end
-          prompt.multi_select("", choices, **opts)
+          prompt.multi_select("", choices, **opts).compact
         when 'time'
           prompt.ask("TEXT > ") do |q|
             q.default default


### PR DESCRIPTION
Previously, if the dynamic directory listing was empty an error could occur.  Now a `(no matching files found)` option is added which evaluates to `nil` / `[]` depending on whether question is a select or multiselect.