### PR TITLE
Warn user when copying a template without defaults

### DIFF
--- a/lib/flight_job/commands/copy_template.rb
+++ b/lib/flight_job/commands/copy_template.rb
@@ -29,6 +29,14 @@ module FlightJob
   module Commands
     class CopyTemplate < Command
       def run
+        # Check for nil defaults before rendering, as a nil working
+        # directory raises an error.
+        without_defaults = template.without_defaults
+        if without_defaults.any?
+          $stderr.puts <<~INFO.chomp
+            WARNING: Copied template is missing default values for: #{without_defaults.map(&:id).join(', ')}
+          INFO
+        end
         content = render_content
         FileUtils.mkdir_p File.dirname(dst_path)
         File.write(dst_path, content)

--- a/lib/flight_job/commands/copy_template.rb
+++ b/lib/flight_job/commands/copy_template.rb
@@ -33,7 +33,7 @@ module FlightJob
         # directory raises an error.
         without_defaults = template.without_defaults
         if without_defaults.any?
-          $stderr.puts <<~INFO.chomp
+          $stderr.puts pastel.yellow <<~INFO.chomp
             WARNING: Copied template is missing default values for: #{without_defaults.map(&:id).join(', ')}
           INFO
         end

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -148,9 +148,10 @@ module FlightJob
     end
 
     def metadata_path
+      # Sometimes we render a script that has no ID; in this case, it doesn't
+      # exist outside of the execution scope, and will not have a path.
+      return nil if id.nil?
       @metadata_path ||= File.join(FlightJob.config.scripts_dir, id, 'metadata.yaml')
-    rescue TypeError
-      nil
     end
 
     def script_path

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -520,6 +520,14 @@ module FlightJob
       end
     end
 
+    def without_defaults
+      # Get all questions with no default key specified. Default keys with an
+      # empty string value are allowed, as it's probably intended.
+      generation_questions.select do |gq|
+        gq.default.nil?
+      end
+    end
+
     def validate_generation_questions_values(hash)
       @validate_generation_questions_values ||= JSONSchemer.schema({
         "type" => "object",


### PR DESCRIPTION
This PR aims to add a warning given to the user when copying a template containing questions without a default value. When copying such a template, `stderr` is given a warning and a list of questions which are missing a default value. The copy takes place nonetheless.

The PR also fixes a related issue where a script could not be rendered if it did not have an ID (which it does not when rendering for the purpose of writing to a new template file).