### PR TITLE
Mark invalid templates when listing templates

### DIFF
--- a/lib/flight_job/command.rb
+++ b/lib/flight_job/command.rb
@@ -180,7 +180,7 @@ module FlightJob
     def load_template(name_or_id)
       template = Template.new(id: name_or_id)
       if template.exists?
-        unless template.valid?(:verbose)
+        unless template.valid?
           FlightJob.logger.error("Failed to load invalid template: #{template.id}")
           FlightJob.logger.warn(template.errors.full_messages.join("\n"))
           raise InternalError, <<~ERROR.chomp
@@ -202,7 +202,7 @@ module FlightJob
           ERROR
         end
         templates[index].tap do |template|
-          unless template.valid?(:verbose)
+          unless template.valid?
             FlightJob.logger.error("Failed to load invalid template: #{template.id}")
             FlightJob.logger.warn(template.errors.full_messages.join("\n"))
             raise InternalError, <<~ERROR

--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -123,7 +123,7 @@ module FlightJob
       template = load_template
       if template.nil?
         errors.add(:template, 'could not be resolved')
-      elsif ! template.valid?(:verbose)
+      elsif !template.valid?
         errors.add(:template, 'is not valid')
         FlightJob.logger.info("Template errors: #{template_id}\n") do
           template.errors.full_messages.join("\n")

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -357,30 +357,25 @@ module FlightJob
                    .merge!(QUESTION_DEF)
     })
 
-    def self.load_all(validate: true)
+    def self.load_all
       templates = Dir.glob(new(id: '*').metadata_path).map do |path|
         id = File.basename(File.dirname(path))
         new(id: id)
       end
 
-      if validate
-        templates.select do |template|
-          next true if template.valid?
-          FlightJob.logger.error("Failed to load missing/invalid template: #{template.id}")
-          FlightJob.logger.warn(template.errors.full_messages.join("\n"))
-          false
-        end
-
-        templates.sort!
-
-        templates.each_with_index do |t, idx|
-          t.index = idx + 1
-        end
-
-        templates
-      else
-        templates
+      templates.each do |template|
+        next if template.valid?
+        FlightJob.logger.warn("Invalid template detected upon load: #{template.id}")
+        FlightJob.logger.warn(template.errors.full_messages.join("\n"))
       end
+
+      templates.sort!
+
+      templates.each_with_index do |t, idx|
+        t.index = idx + 1
+      end
+
+      templates
     end
 
     attr_accessor :id, :index

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -421,10 +421,8 @@ module FlightJob
           errors.add(:metadata, 'is not valid')
         end
       end
-    end
 
-    # Validates the workload_path and directives_path
-    validate do
+      # Validates the workload_path and directives_path
       unless File.exists? workload_path
         legacy_path = File.join(FlightJob.config.templates_dir, id, "#{script_template_name}.erb")
         if File.exists?(legacy_path)
@@ -435,9 +433,7 @@ module FlightJob
           errors.add(:workload_path, "does not exist")
         end
       end
-    end
 
-    validate on: :verbose do
       # Ensure the questions are sorted correctly
       begin
         next unless errors.empty?

--- a/lib/flight_job/outputs/list_templates.rb
+++ b/lib/flight_job/outputs/list_templates.rb
@@ -34,7 +34,11 @@ module FlightJob
         template.index
       end
       register(header: 'Name') do |template|
-        template.id
+        if template.errors.any?
+          "#{template.id} **INVALID**"
+        else
+          template.id
+        end
       end
       file_header = "File (Dir: #{FlightJob.config.templates_dir})"
 

--- a/lib/flight_job/outputs/list_templates.rb
+++ b/lib/flight_job/outputs/list_templates.rb
@@ -29,13 +29,24 @@ require 'output_mode'
 
 module FlightJob
   class Outputs::ListTemplates < OutputMode::Formatters::Index
+    # Override "render" method to add invalid template footnote
+    def render(*a, **o)
+      super.tap do |txt|
+        next unless humanize?
+        next unless @invalid_template
+        txt << "\n"
+        txt << pastel.yellow(" * Invalid template")
+      end
+    end
+
     def register_all
       register(header: 'Index', row_color: :yellow) do |template|
         template.index
       end
       register(header: 'Name') do |template|
         if template.errors.any?
-          "#{template.id} **INVALID**"
+          @invalid_template = true
+          pastel.yellow "#{template.id}*"
         else
           template.id
         end
@@ -51,6 +62,10 @@ module FlightJob
           end
         end
       end
+    end
+
+    def pastel
+      @pastel ||= Pastel.new(enabled: color?)
     end
   end
 end


### PR DESCRIPTION
This PR introduces a pair of changes to the template validation workflow in Flight Job.

The first of these changes removes the separation of 'verbose' and 'regular' validations. All `.valid?` calls on a `template` run the same set of validations every time (which is now all of the previously separate validations grouped into one).

The second change adds validations to the `list-templates` command. Now, when listing templates, if a template is invalid, its row in the resulting table will be highlighted and marked as being invalid.