### PR TITLE
Re-implement old method of grabbing results directory

### DIFF
--- a/config/schemas/job/version2.json
+++ b/config/schemas/job/version2.json
@@ -243,6 +243,10 @@
           "type": "string",
           "minLength": 1
         },
+        "results_dir": {
+          "type": "string",
+          "minLength": 1
+        },
         "job_type": {
           "const": "SINGLETON"
         },
@@ -365,6 +369,10 @@
           "type": "string"
         },
         "scheduler_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "results_dir": {
           "type": "string",
           "minLength": 1
         },

--- a/config/schemas/job/version2.template.yaml
+++ b/config/schemas/job/version2.template.yaml
@@ -32,7 +32,8 @@ __meta__:
   # Additional properties once the bootstrapping script has ran.
   BOOTSTRAP_STATUS_REQUIRED: &BOOTSTRAP_STATUS_REQUIRED
     required: []
-  BOOTSTRAP_STATUS_PROPERTIES: &BOOTSTRAP_STATUS_PROPERTIES {}
+  BOOTSTRAP_STATUS_PROPERTIES: &BOOTSTRAP_STATUS_PROPERTIES
+    results_dir: { "type" : "string", "minLength" : 1}
 
   STATES_ENUM: &STATES_ENUM
     enum: ["PENDING", "RUNNING", "COMPLETING", "FAILED", "COMPLETED", "CANCELLED", "UNKNOWN"]

--- a/lib/flight_job/job_transitions/bootstrap_monitor.rb
+++ b/lib/flight_job/job_transitions/bootstrap_monitor.rb
@@ -33,7 +33,8 @@ module FlightJob
       "required" => ["job_type", "version"],
       "properties" => {
         "version" => { "const" => 2 },
-        "job_type" => { "enum" => ["SINGLETON", "ARRAY"] }
+        "job_type" => { "enum" => ["SINGLETON", "ARRAY"] },
+        "results_dir" => { "type" => "string", "minLength" => 1 }
       }
     })
 
@@ -56,6 +57,7 @@ module FlightJob
           raise_command_error unless status.success?
 
           validate_data(BOOTSTRAP_SCHEMA, data, tag: "bootstrap")
+          job.metadata['results_dir'] = data['results_dir']
           job.metadata['job_type'] = data['job_type']
           job.metadata['cancelling'] = false
 

--- a/usr/share/job/adapter.slurm.erb
+++ b/usr/share/job/adapter.slurm.erb
@@ -8,16 +8,18 @@
 # The controls directory is used internally to track various flight-job data
 # files.  This is used to store the desktop session ID of the interactive
 # session.
-mkdir -p "$CONTROLS_DIR"
+if [ "${CONTROLS_DIR}" != "" ]; then
+  mkdir -p "${CONTROLS_DIR}"
+fi
 
 register_control() {
   name=$1
   value=$2
-  if [ "$CONTROLS_DIR}" == "" ]; then
-    echo "CONTROLS_DIR has not been set." >&2
-    echo "${name} ${value}"
-  else
+  if [ -d "${CONTROLS_DIR}" ]; then
     echo "${value}" > "${CONTROLS_DIR}/${name}"
+  else
+    echo "CONTROLS_DIR has not been set or is not a directory" >&2
+    echo "${name} ${value}"
   fi
 }
 

--- a/usr/share/job/templates/interactive-desktop/workload.erb
+++ b/usr/share/job/templates/interactive-desktop/workload.erb
@@ -20,9 +20,8 @@ SESSION_OUTPUT="${RESULTS_DIR}/session.output"
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB_NAME}-outputs/$SLURM_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"

--- a/usr/share/job/templates/mpi-nodes/workload.erb
+++ b/usr/share/job/templates/mpi-nodes/workload.erb
@@ -38,9 +38,8 @@ fi
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB_NAME}-outputs/$SLURM_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"

--- a/usr/share/job/templates/mpi-slots/workload.erb
+++ b/usr/share/job/templates/mpi-slots/workload.erb
@@ -38,9 +38,8 @@ fi
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB_NAME}-outputs/$SLURM_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"

--- a/usr/share/job/templates/simple-array/workload.erb
+++ b/usr/share/job/templates/simple-array/workload.erb
@@ -34,9 +34,8 @@ source "${flight_ROOT:-/opt/flight}"/etc/setup.sh
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB-NAME}-outputs/$SLURM_ARRAY_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"

--- a/usr/share/job/templates/simple/workload.erb
+++ b/usr/share/job/templates/simple/workload.erb
@@ -31,9 +31,8 @@ source "${flight_ROOT:-/opt/flight}"/etc/setup.sh
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB_NAME}-outputs/$SLURM_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"

--- a/usr/share/job/templates/smp/workload.erb
+++ b/usr/share/job/templates/smp/workload.erb
@@ -31,9 +31,8 @@ source "${flight_ROOT:-/opt/flight}"/etc/setup.sh
 # saved there.
 #
 # Your job can save its results anywhere you want, but if the results are
-# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you
-# access your results.
-
+# saved outside of RESULTS_DIR, 'flight-job' will be unable to help you access
+# your results.
 RESULTS_DIR="$(pwd)/${SLURM_JOB_NAME}-outputs/$SLURM_JOB_ID"
 register_control "results_dir" "${RESULTS_DIR}"
 echo "Your results will be stored in: $RESULTS_DIR"


### PR DESCRIPTION
Backwards compatibility dictates that the new version of the application must be able to accommodate scripts created via the old version. Newly created scripts should now have an automatically generated results directory in the job metadata, as well as in the controls directory. The controls directory method is always preferred; however, when the results directory control file is not present (as is the case for version 1 scripts), the application falls back to the results directory present in the job metadata.