### PR TITLE
Avoid unsetting scheduler id for interactive jobs

### DIFF
--- a/usr/share/job/adapter.slurm.erb
+++ b/usr/share/job/adapter.slurm.erb
@@ -31,7 +31,9 @@ register_control() {
       value="$2"
   fi
   if [ -d "${CONTROLS_DIR}" ]; then
-    echo "${value}" > "${CONTROLS_DIR}/${name}"
+    if [ -n ${value} ]; then
+        echo "${value}" > "${CONTROLS_DIR}/${name}"
+    fi
   else
     echo "CONTROLS_DIR has not been set or is not a directory" >&2
     echo "${name} ${value}"


### PR DESCRIPTION
If an interactive job starts immediately, the scheduler id control is set when the job script runs on the client.  It is then unset when the `srun` script completes without printing out the scheduler's id.

If the job has not been processed by Flight Job in the mean time this can result in Flight Job "losing"  the job's scheduler id.

The fix to this is to not write empty values to control files.  There are no valid situations where an emtpy value is valid or where we'd like to unset a control file.