### PR TITLE
Markdown descriptions

### DIFF
--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -47,6 +47,7 @@ module FlightJob
       "properties" => {
         "copyright" => { "type" => "string" },
         "description" => { "type" => "string" },
+        "description_markdown" => { "type" => "string" },
         "generation_questions" => {
           "type" => "array",
           "items" => { "$ref" => "#/$defs/question_def" }
@@ -236,6 +237,10 @@ module FlightJob
     
     def description
        metadata['description']
+    end
+
+    def description_markdown
+      metadata['description_markdown'] ||= metadata['description']
     end
     
     def tags

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -234,6 +234,10 @@ module FlightJob
        metadata['license']
     end
     
+    def synopsis
+       metadata['synopsis']
+    end
+
     def description
        metadata['description']
     end

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -47,7 +47,6 @@ module FlightJob
       "properties" => {
         "copyright" => { "type" => "string" },
         "description" => { "type" => "string" },
-        "description_markdown" => { "type" => "string" },
         "generation_questions" => {
           "type" => "array",
           "items" => { "$ref" => "#/$defs/question_def" }
@@ -239,10 +238,6 @@ module FlightJob
        metadata['description']
     end
 
-    def description_markdown
-      metadata['description_markdown'] ||= metadata['description']
-    end
-    
     def tags
       metadata['tags'] || []
     end

--- a/lib/flight_job/outputs/info_script.rb
+++ b/lib/flight_job/outputs/info_script.rb
@@ -26,9 +26,11 @@
 #==============================================================================
 
 require 'output_mode'
+require_relative '../markdown_renderer'
 
 module FlightJob
   class Outputs::InfoScript < OutputMode::Formatters::Show
+
     def register_all
       template(<<~ERB) if humanize?
         <% each(:main) do |value, field:, padding:, **_| -%>
@@ -51,7 +53,13 @@ module FlightJob
         Time.parse script.created_at
       end
 
-      register(section: :notes, header: 'Notes') { |s| s.notes }
+      if humanize?
+        notes = MarkdownRenderer.new(object.notes).wrap_markdown
+      else
+        notes = object.notes
+      end
+      register(section: :notes, header: 'Notes') { notes }
     end
   end
 end
+

--- a/lib/flight_job/outputs/info_template.rb
+++ b/lib/flight_job/outputs/info_template.rb
@@ -47,6 +47,7 @@ module FlightJob
       # NOTE: The verbose output is at the end to avoid the order changing
       register(section: :main, header: 'ID') { |s| s.id }
       register(section: :main, header: 'Name') { |s| s.name }
+      register(section: :main, header: 'Synopsis') { |s| s.synopsis }
       register(section: :main, header: 'Copyright') { |s| s.copyright } if verbose?
       register(section: :main, header: 'License') { |s| s.license } if verbose?
 

--- a/lib/flight_job/outputs/info_template.rb
+++ b/lib/flight_job/outputs/info_template.rb
@@ -51,7 +51,7 @@ module FlightJob
       register(section: :main, header: 'License') { |s| s.license } if verbose?
 
       if humanize?
-        description = MarkdownRenderer.new(object.description_markdown).wrap_markdown
+        description = MarkdownRenderer.new(object.description).wrap_markdown
       else
         description = object.description
       end

--- a/lib/flight_job/outputs/info_template.rb
+++ b/lib/flight_job/outputs/info_template.rb
@@ -30,6 +30,7 @@ require_relative '../markdown_renderer'
 
 module FlightJob
   class Outputs::InfoTemplate < OutputMode::Formatters::Show
+    
     def register_all
       # Intentionally overwrite the template in all modes
       template(<<~ERB) if humanize?
@@ -43,13 +44,19 @@ module FlightJob
         <% end -%>
       ERB
 
-      register(section: :main, header: 'ID') { |s| s.id }
-      
       # NOTE: The verbose output is at the end to avoid the order changing
+      register(section: :main, header: 'ID') { |s| s.id }
       register(section: :main, header: 'Name') { |s| s.name }
       register(section: :main, header: 'Copyright') { |s| s.copyright } if verbose?
       register(section: :main, header: 'License') { |s| s.license } if verbose?
-      register(section: :notes, header: 'Description') { |s| s.description }
+
+      if humanize?
+        description = MarkdownRenderer.new(object.description_markdown).wrap_markdown
+      else
+        description = object.description
+      end
+      register(section: :notes, header: 'Description') { description }
+
     end
   end
 end

--- a/usr/share/job/templates/desktop-on-compute-node/metadata.yaml
+++ b/usr/share/job/templates/desktop-on-compute-node/metadata.yaml
@@ -10,9 +10,9 @@ tags:
   - session:order=alloc:desktop
 synopsis: Submit a job to run an interactive desktop session.
 description: |
-  Your job will start an interactive session on the first available node.  You
-  can optionally provide a session script to configure and launch an
-  interactive application.
+  Your job will start an interactive desktop session on the first available
+  node.  You can optionally provide a session script to configure and launch
+  an interactive or graphical application.
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/desktop-on-login-node/metadata.yaml
+++ b/usr/share/job/templates/desktop-on-login-node/metadata.yaml
@@ -12,7 +12,8 @@ synopsis: Start an interactive desktop session on a login node and submit a job 
 description: |
   An interactive desktop session will start on a login node.  Once that
   session is running, resources will be requested from the scheduler to run
-  that job script.
+  the job script.  If the job script starts a graphical application it will be
+  available from inside the desktop session.
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/mpi-nodes/metadata.yaml
+++ b/usr/share/job/templates/mpi-nodes/metadata.yaml
@@ -9,8 +9,9 @@ tags:
 synopsis: Submit a single job that spans multiple nodes where you want exclusive use of each node allocated. 
 description: |
   This may be because you intend to spawn multiple threads yourself or intend
-  to run an MPI application. This method is often used for MPI jobs where you
-  need to specify the number of processes, machine file and process allocation
+  to run an [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface)
+  application. This method is often used for MPI jobs where you need to
+  specify the number of processes, machine file and process allocation
   manually, rather than leave this up to the scheduler.
 
   Your job will be allocated the requested number of empty nodes. This method

--- a/usr/share/job/templates/mpi-slots/metadata.yaml
+++ b/usr/share/job/templates/mpi-slots/metadata.yaml
@@ -10,14 +10,15 @@ synopsis: Submit a single job that has multiple processes that may span multiple
 description: |
   This allows you to specify the total number of cores required for a job whilst
   leaving it up to the scheduler to allocate them. This method is often used for
-  MPI jobs where you know the required number of processes in advance but do not
-  need exclusive access to the machine.
+  [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) jobs where
+  you know the required number of processes in advance but do not need
+  exclusive access to the machine.
 
-  Your job will be allocated the requested number of cores across the allocated
-  nodes. The remaining unallocated cores maybe shared with other jobs. This method
-  should not be used for SMP (OpenMP) jobs. As this method allocates individual
-  cores, you may need to share the nodes' resources. You may prefer using a
-  multiple mpi node job to obtain exclusive access instead.
+  Your job will be allocated the requested number of cores across the
+  allocated nodes. The remaining unallocated cores maybe shared with other
+  jobs. This method should not be used for SMP (OpenMP) jobs. As this method
+  allocates individual cores, you may need to share the nodes' resources. You
+  may prefer using a multiple mpi node job to obtain exclusive access instead.
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/simple-array/metadata.yaml
+++ b/usr/share/job/templates/simple-array/metadata.yaml
@@ -12,6 +12,14 @@ description: |
   this when you wish to spawn multiple jobs, making use of environment
   variables to differentiate each job. This method should not be used for
   multi-threaded, SMP or MPI jobs.
+description_markdown: |
+  <p>Each job will be allocated a single core on the first available node.</p> <br>
+
+  <p>Use this when you wish to spawn multiple jobs, making use of environment
+  variables to differentiate each job.</p> <br>
+
+  <p>This method should not be used for multi-threaded, SMP or MPI jobs.</p> <br>
+
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/simple-array/metadata.yaml
+++ b/usr/share/job/templates/simple-array/metadata.yaml
@@ -12,14 +12,6 @@ description: |
   this when you wish to spawn multiple jobs, making use of environment
   variables to differentiate each job. This method should not be used for
   multi-threaded, SMP or MPI jobs.
-description_markdown: |
-  <p>Each job will be allocated a single core on the first available node.</p> <br>
-
-  <p>Use this when you wish to spawn multiple jobs, making use of environment
-  variables to differentiate each job.</p> <br>
-
-  <p>This method should not be used for multi-threaded, SMP or MPI jobs.</p> <br>
-
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/simple-array/metadata.yaml
+++ b/usr/share/job/templates/simple-array/metadata.yaml
@@ -11,7 +11,9 @@ description: |
   Each job will be allocated a single core on the first available node. Use
   this when you wish to spawn multiple jobs, making use of environment
   variables to differentiate each job. This method should not be used for
-  multi-threaded, SMP or MPI jobs.
+  multi-threaded,
+  [SMP](https://en.wikipedia.org/wiki/Symmetric_multiprocessing) or
+  [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface) jobs.
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\

--- a/usr/share/job/templates/smp/metadata.yaml
+++ b/usr/share/job/templates/smp/metadata.yaml
@@ -12,8 +12,8 @@ description: |
   single node. The remaining cores will be shared with other jobs.
 
   As this method allocates cores on a single machine, it may take longer to
-  allocate your job. You may wish to consider using a mpi slots job to reserve
-  cores over multiple nodes.
+  allocate your job. You may wish to consider using an MPI slots job to
+  reserve cores over multiple nodes.
 
 __meta__:
   SLURM_TIME: &SLURM_TIME "^\


### PR DESCRIPTION
For templates, added the ability to read description_markdown field from metadata.yaml, if it exists. The description will then be rendered as markdown if the humanize? option is active. If the description_markdown field doesn't exist, the plain text version is read in as before. I added an example description_markdown field to the simple-array template.

For scripts, no separate notes file dedicated to markdown, just rendering as markdown if the humanize option is active. I didn't think it made sense to have separate versions here for markdown/ plain text, but let me know if you want me to add that.