### PR TITLE
Desktop names from job ID

### DIFF
--- a/lib/flight_job/desktop_cli.rb
+++ b/lib/flight_job/desktop_cli.rb
@@ -83,6 +83,7 @@ module FlightJob
         'USER' => username,
         'LOGNAME' => username,
       }.merge(env)
+      @cmd = cmd + ["--name", @env['FLIGHT_JOB_ID']]
     end
 
     def run_local(&block)

--- a/usr/share/job/adapter.slurm.erb
+++ b/usr/share/job/adapter.slurm.erb
@@ -208,10 +208,12 @@ session_start() {
     echo "Starting session..."
     (
         set -o pipefail
-        ${flight_ROOT:-/opt/flight}/bin/flight desktop \
+        # ${flight_ROOT:-/opt/flight}/bin/flight desktop \
+        /code/flight-desktop/bin/desktop \
             start \
             --script ${SESSION_SCRIPT} \
             --no-override-env \
+            --name ${FLIGHT_JOB_ID} \
             | tee >( grep '^Identity' | cut -f2 | register_control "flight_desktop_id" )
     )
 
@@ -222,7 +224,8 @@ session_start() {
 session_is_active() {
     local state
     state=$(
-        ${flight_ROOT:-/opt/flight}/bin/flight desktop \
+        # ${flight_ROOT:-/opt/flight}/bin/flight desktop \
+        /code/flight-desktop/bin/desktop \
             show "${SESSION_ID}" 2>/dev/null \
             | grep '^State' \
             | cut -d $'\t' -f 2

--- a/usr/share/job/templates/..notes.md
+++ b/usr/share/job/templates/..notes.md
@@ -1,0 +1,1 @@
+Example notes

--- a/usr/share/job/templates/mpi-nodes/notes.md
+++ b/usr/share/job/templates/mpi-nodes/notes.md
@@ -1,0 +1,1 @@
+Default notes for the template.

--- a/usr/share/job/templates/mpi-slots/notes.md
+++ b/usr/share/job/templates/mpi-slots/notes.md
@@ -1,0 +1,1 @@
+Default notes for the template.

--- a/usr/share/job/templates/notes.md
+++ b/usr/share/job/templates/notes.md
@@ -1,0 +1,1 @@
+Default notes for the template.


### PR DESCRIPTION
Automatically names interactive desktop sessions on login and compute nodes, where the name is the job ID.

I've left the path pointing to the dev version of flight desktop in `/code/flight-job/usr/share/job/adapter.slurm.erb` for testing, I wasn't sure when would be a good time to put it back to pointing to the rpm version.