### PR TITLE
Fix error handling for failed interactive jobs

### DIFF
--- a/lib/flight_job/commands/submit_job.rb
+++ b/lib/flight_job/commands/submit_job.rb
@@ -148,6 +148,9 @@ module FlightJob
           job.desktop_id = result.desktop_id
         else
           job.metadata['job_type'] = 'FAILED_SUBMISSION'
+          job.metadata['submit_status'] = result.exitstatus
+          job.metadata['submit_stdout'] = result.stdout
+          job.metadata['submit_stderr'] = result.stderr
           job.save
         end
       end


### PR DESCRIPTION
Previously if an interactive job on login node fails due to the desktop type not being verified, the job would be invalid, due to the exit status, stdout and stderr not being saved.

Now, we save them.  Allowing the reason for the failure to be inspected.