### PR TITLE
Fix copy-template command

### DIFF
--- a/lib/flight_job/models/script.rb
+++ b/lib/flight_job/models/script.rb
@@ -194,7 +194,7 @@ module FlightJob
     end
 
     def metadata
-      @metadata ||= if File.exist?(metadata_path)
+      @metadata ||= if !metadata_path.nil? && File.exist?(metadata_path)
                       Metadata.load_from_path(metadata_path, self)
                     else
                       Flight.logger.warn("Setting metadata to empty hash for script #{id}; this probably isn't right")

--- a/lib/flight_job/models/script/metadata.rb
+++ b/lib/flight_job/models/script/metadata.rb
@@ -94,6 +94,9 @@ module FlightJob
       end
 
       def persisted?
+        # Sometimes we render a script that has no ID; in this case, it doesn't
+        # exist outside of the execution scope, and will not have a path.
+        return nil if @path.nil?
         File.exist?(@path)
       end
     end


### PR DESCRIPTION
It was recently broken by refactoring of the script metadata.  We need to handle the case that a script is not given an ID, does not have a script dir and will never be saved to the filesystem.