### PR TITLE
Fix webapp issues

### DIFF
--- a/lib/flight_job/commands/list_scripts.rb
+++ b/lib/flight_job/commands/list_scripts.rb
@@ -37,7 +37,17 @@ module FlightJob
       end
 
       def scripts
-        @scripts ||= Script.load_all(opts)
+        @scripts ||=
+          begin
+            scripts = Script.load_all(opts)
+            if opts.json
+              # Prevent invalid scripts from reaching the webapp.  Not ideal,
+              # but a decent workaround until the webapp can be updated.
+              scripts.reject { |s| !s.errors.empty? }
+            else
+              scripts
+            end
+          end
       end
     end
   end

--- a/lib/flight_job/commands/list_templates.rb
+++ b/lib/flight_job/commands/list_templates.rb
@@ -37,7 +37,17 @@ module FlightJob
       end
 
       def templates
-        @templates ||= Template.load_all(opts)
+        @templates ||=
+          begin
+            templates = Template.load_all(opts)
+            if opts.json
+              # Prevent invalid templates from reaching the webapp.  Not ideal,
+              # but a decent workaround until the webapp can be updated.
+              templates.reject { |t| !t.errors.empty? }
+            else
+              templates
+            end
+          end
       end
     end
   end

--- a/lib/flight_job/models/template.rb
+++ b/lib/flight_job/models/template.rb
@@ -99,7 +99,7 @@ module FlightJob
 
     def serializable_hash(opts = nil)
       opts ||= {}
-      md = metadata.except("generation_questions", "submission_questions", "__meta__")
+      md = metadata.to_hash.except("generation_questions", "submission_questions", "__meta__")
       md.merge(
         'id' => id,
         'path' => workload_path,


### PR DESCRIPTION
1. Listing templates with the `--json` flag was broken.
2. Prevent invalid templates from reaching the webapp.
3. Prevent invalid scripts from reaching the webapp.

We continue to allow broken (aka invalid) jobs to reach the webapp. They are marked as such and for the most part behave reasonably well.