### PR TITLE
Return nil if script is unknown

### DIFF
--- a/lib/flight_job/decorators/job_decorator.rb
+++ b/lib/flight_job/decorators/job_decorator.rb
@@ -218,7 +218,8 @@ module FlightJob
           hash["stderr_size"] = File.size(stderr_path) if object.stderr_readable?
 
           if Flight.config.includes.include? 'script'
-            hash['script'] = object.load_script
+            script = object.load_script
+            hash['script'] = script.persisted? ? script : nil
           end
 
           # Always serialize the result_files


### PR DESCRIPTION
If the script for a job being decorated is unknown to the filesystem, set the job's script as nil.